### PR TITLE
Allow format to fix indent when no lint is provided

### DIFF
--- a/extension/server/src/providers/linter/documentFormatting.ts
+++ b/extension/server/src/providers/linter/documentFormatting.ts
@@ -11,71 +11,73 @@ export default async function documentFormattingProvider(params: DocumentFormatt
 	if (document) {
 		const isFree = (document.getText(Range.create(0, 0, 0, 6)).toUpperCase() === `**FREE`);
 		if (isFree) {
-			const options = await getLintOptions(document.uri);
+			let options = (await getLintOptions(document.uri));
+			let docs = await parser.getDocs(document.uri);
 
-			if (options) {
-				let docs = await parser.getDocs(document.uri);
+			// If no lint config is provided, then set a default for indent
+			if (Object.keys(options).length === 0) {
+				options.indent = params.options.tabSize;
+			}
 
-				if (docs) {
-					// Need to fetch the docs again incase comments were added
-					// as part of RequiresProcedureDescription
-					docs = await parser.getDocs(document.uri, document.getText(), {
-						ignoreCache: true
-					});
+			if (docs) {
+				// Need to fetch the docs again incase comments were added
+				// as part of RequiresProcedureDescription
+				docs = await parser.getDocs(document.uri, document.getText(), {
+					ignoreCache: true
+				});
 
-					// Next up, let's fix all the other things!
-					const { errors } = Linter.getErrors({
-						uri: document.uri,
-						content: document.getText()
-					}, options, docs);
+				// Next up, let's fix all the other things!
+				const { errors } = Linter.getErrors({
+					uri: document.uri,
+					content: document.getText()
+				}, options, docs);
 
 
-					const actions = getActions(
-						document,
-						errors.filter(error => error.type !== `RequiresProcedureDescription`)
-					);
+				const actions = getActions(
+					document,
+					errors.filter(error => error.type !== `RequiresProcedureDescription`)
+				);
 
-					let linesChanged: number[] = [];
-					let skippedChanges: number = 0;
+				let linesChanged: number[] = [];
+				let skippedChanges: number = 0;
 
-					let fixes: TextEdit[] = [];
+				let fixes: TextEdit[] = [];
 
-					actions
-						.filter(action => action.edit)
-						.forEach(action => {
-							if (action.edit && action.edit.changes) {
-								const uris = action.edit.changes;
-								const suggestedEdits = uris[document.uri];
-								const editedLineBefore = suggestedEdits[0] ? linesChanged.includes(suggestedEdits[0].range.start.line) : false;
-								if (!editedLineBefore) {
-									suggestedEdits.forEach(edit => {
-										const changedLine = edit.range.start.line;
-										fixes.push(edit);
+				actions
+					.filter(action => action.edit)
+					.forEach(action => {
+						if (action.edit && action.edit.changes) {
+							const uris = action.edit.changes;
+							const suggestedEdits = uris[document.uri];
+							const editedLineBefore = suggestedEdits[0] ? linesChanged.includes(suggestedEdits[0].range.start.line) : false;
+							if (!editedLineBefore) {
+								suggestedEdits.forEach(edit => {
+									const changedLine = edit.range.start.line;
+									fixes.push(edit);
 
-										if (!linesChanged.includes(changedLine)) {
-											linesChanged.push(changedLine);
-										}
-									});
-								} else {
-									skippedChanges += 1;
-								}
+									if (!linesChanged.includes(changedLine)) {
+										linesChanged.push(changedLine);
+									}
+								});
+							} else {
+								skippedChanges += 1;
 							}
-						});
-
-
-					// First we do all the indentation fixes.
-					const { indentErrors } = Linter.getErrors({
-						uri: document.uri,
-						content: document.getText()
-					}, options, docs);
-
-					const indentFixes = indentErrors.map(error => {
-						const range = Range.create(error.line, 0, error.line, error.currentIndent);
-						return TextEdit.replace(range, ``.padEnd(error.expectedIndent, ` `));
+						}
 					});
 
-					return [...fixes, ...indentFixes];
-				}
+
+				// First we do all the indentation fixes.
+				const { indentErrors } = Linter.getErrors({
+					uri: document.uri,
+					content: document.getText()
+				}, options, docs);
+
+				const indentFixes = indentErrors.map(error => {
+					const range = Range.create(error.line, 0, error.line, error.currentIndent);
+					return TextEdit.replace(range, ``.padEnd(error.expectedIndent, ` `));
+				});
+
+				return [...fixes, ...indentFixes];
 			}
 		}
 	}

--- a/extension/server/src/providers/linter/index.ts
+++ b/extension/server/src/providers/linter/index.ts
@@ -158,7 +158,7 @@ export async function getLintConfigUri(workingUri: string) {
 	return cleanString;
 }
 
-export async function getLintOptions(workingUri: string) {
+export async function getLintOptions(workingUri: string): Promise<Rules> {
 	const possibleUri = await getLintConfigUri(workingUri);
 	let result = {};
 


### PR DESCRIPTION
### Changes

Allows the formatter (Format Document) to fix indentation without requiring a lint configuration to be defined.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
