### PR TITLE
Add lowercase directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 - [@p-behr](https://github.com/p-behr)
 - [@chrjorgensen](https://github.com/chrjorgensen)
 - [@sebjulliand](https://github.com/sebjulliand)
+- [@richardm90](https://github.com/richardm90)

--- a/extension/server/src/providers/linter/documentFormatting.ts
+++ b/extension/server/src/providers/linter/documentFormatting.ts
@@ -23,7 +23,8 @@ export default async function documentFormattingProvider(params: DocumentFormatt
 				// Need to fetch the docs again incase comments were added
 				// as part of RequiresProcedureDescription
 				docs = await parser.getDocs(document.uri, document.getText(), {
-					ignoreCache: true
+					ignoreCache: true,
+					withIncludes: true
 				});
 
 				// Next up, let's fix all the other things!

--- a/extension/server/src/providers/linter/documentFormatting.ts
+++ b/extension/server/src/providers/linter/documentFormatting.ts
@@ -23,8 +23,7 @@ export default async function documentFormattingProvider(params: DocumentFormatt
 				// Need to fetch the docs again incase comments were added
 				// as part of RequiresProcedureDescription
 				docs = await parser.getDocs(document.uri, document.getText(), {
-					ignoreCache: true,
-					withIncludes: true
+					ignoreCache: true
 				});
 
 				// Next up, let's fix all the other things!

--- a/extension/server/src/providers/linter/index.ts
+++ b/extension/server/src/providers/linter/index.ts
@@ -343,7 +343,7 @@ export function getActions(document: TextDocument, errors: IssueRange[]) {
 
 			case `RequireBlankSpecial`:
 				if (error.newValue) {
-					action = CodeAction.create(`Convert constant name to uppercase`, CodeActionKind.QuickFix);
+					action = CodeAction.create(`Convert empty string literal to *BLANK`, CodeActionKind.QuickFix);
 					action.edit = {
 						changes: {
 							[document.uri]: [

--- a/extension/server/src/providers/linter/index.ts
+++ b/extension/server/src/providers/linter/index.ts
@@ -314,7 +314,7 @@ export function getActions(document: TextDocument, errors: IssueRange[]) {
 
 			case `SpecificCasing`:
 			case `IncorrectVariableCase`:
-			case `LowercaseDirectives`:
+			case `DirectiveCasing`:
 			case `UppercaseDirectives`:
 				if (error.newValue) {
 					action = CodeAction.create(`Correct casing to '${error.newValue}'`, CodeActionKind.QuickFix);

--- a/extension/server/src/providers/linter/index.ts
+++ b/extension/server/src/providers/linter/index.ts
@@ -314,6 +314,7 @@ export function getActions(document: TextDocument, errors: IssueRange[]) {
 
 			case `SpecificCasing`:
 			case `IncorrectVariableCase`:
+			case `LowercaseDirectives`:
 			case `UppercaseDirectives`:
 				if (error.newValue) {
 					action = CodeAction.create(`Correct casing to '${error.newValue}'`, CodeActionKind.QuickFix);

--- a/language/linter.ts
+++ b/language/linter.ts
@@ -27,7 +27,7 @@ const errorText = {
   'RequireBlankSpecial': `\`*BLANK\` should be used over empty string literals.`,
   'CopybookDirective': `Directive does not match requirement.`,
   'DirectiveCasing': `Does not match required case.`,
-  'UppercaseDirectives': `Directives must be in uppercase.`,
+  'UppercaseDirectives': `Directives must be in uppercase. UppercaseDirectives option is deprecated, consider using DirectiveCasing.`,
   'NoSQLJoins': `SQL joins are not allowed. Consider creating a view instead.`,
   'NoGlobalsInProcedures': `Global variables should not be referenced in procedures.`,
   'NoCTDATA': `\`CTDATA\` is not allowed.`,

--- a/language/linter.ts
+++ b/language/linter.ts
@@ -26,6 +26,7 @@ const errorText = {
   'StringLiteralDupe': `Same string literal used more than once. Consider using a constant instead.`,
   'RequireBlankSpecial': `\`*BLANK\` should be used over empty string literals.`,
   'CopybookDirective': `Directive does not match requirement.`,
+  'LowercaseDirectives': `Directives must be in lowercase.`,
   'UppercaseDirectives': `Directives must be in uppercase.`,
   'NoSQLJoins': `SQL joins are not allowed. Consider creating a view instead.`,
   'NoGlobalsInProcedures': `Global variables should not be referenced in procedures.`,
@@ -203,15 +204,6 @@ export default class Linter {
 
               case `directive`:
                 value = statement[0].value;
-                if (rules.UppercaseDirectives) {
-                  if (value !== value.toUpperCase()) {
-                    errors.push({
-                      offset: { position: statement[0].range.start, end: statement[0].range.end },
-                      type: `UppercaseDirectives`,
-                      newValue: value.toUpperCase()
-                    });
-                  }
-                }
 
                 if (rules.CopybookDirective || rules.IncludeMustBeRelative) {
                   if ([`/COPY`, `/INCLUDE`].includes(value.toUpperCase())) {
@@ -291,8 +283,13 @@ export default class Linter {
                     }
 
                     if (rules.CopybookDirective) {
-                      const correctDirective = `/${rules.CopybookDirective.toUpperCase()}`;
-                      if (value.toUpperCase() !== correctDirective) {
+                      let correctDirective = `/${rules.CopybookDirective.toUpperCase()}`;
+                      let correctValue = value.toUpperCase();
+                      if (rules.LowercaseDirectives) {
+                        correctDirective = correctDirective.toLowerCase();
+                        correctValue = value.toLowerCase();
+                      }
+                      if (correctValue !== correctDirective) {
                         errors.push({
                           offset: { position: statement[0].range.start, end: statement[0].range.end },
                           type: `CopybookDirective`,
@@ -302,6 +299,27 @@ export default class Linter {
                     }
                   }
                 }
+
+                if (rules.LowercaseDirectives) {
+                  if (value !== value.toLowerCase()) {
+                    errors.push({
+                      offset: { position: statement[0].range.start, end: statement[0].range.end },
+                      type: `LowercaseDirectives`,
+                      newValue: value.toLowerCase()
+                    });
+                  }
+                }
+
+                if (rules.UppercaseDirectives) {
+                  if (value !== value.toUpperCase()) {
+                    errors.push({
+                      offset: { position: statement[0].range.start, end: statement[0].range.end },
+                      type: `UppercaseDirectives`,
+                      newValue: value.toUpperCase()
+                    });
+                  }
+                }
+
                 break;
 
               case `declare`:

--- a/language/linter.ts
+++ b/language/linter.ts
@@ -26,7 +26,7 @@ const errorText = {
   'StringLiteralDupe': `Same string literal used more than once. Consider using a constant instead.`,
   'RequireBlankSpecial': `\`*BLANK\` should be used over empty string literals.`,
   'CopybookDirective': `Directive does not match requirement.`,
-  'LowercaseDirectives': `Directives must be in lowercase.`,
+  'DirectiveCasing': `Does not match required case.`,
   'UppercaseDirectives': `Directives must be in uppercase.`,
   'NoSQLJoins': `SQL joins are not allowed. Consider creating a view instead.`,
   'NoGlobalsInProcedures': `Global variables should not be referenced in procedures.`,
@@ -285,7 +285,7 @@ export default class Linter {
                     if (rules.CopybookDirective) {
                       let correctDirective = `/${rules.CopybookDirective.toUpperCase()}`;
                       let correctValue = value.toUpperCase();
-                      if (rules.LowercaseDirectives) {
+                      if (rules.DirectiveCasing === `lower`) {
                         correctDirective = correctDirective.toLowerCase();
                         correctValue = value.toLowerCase();
                       }
@@ -300,12 +300,22 @@ export default class Linter {
                   }
                 }
 
-                if (rules.LowercaseDirectives) {
+                if (rules.DirectiveCasing === `lower`) {
                   if (value !== value.toLowerCase()) {
                     errors.push({
                       offset: { position: statement[0].range.start, end: statement[0].range.end },
-                      type: `LowercaseDirectives`,
+                      type: `DirectiveCasing`,
                       newValue: value.toLowerCase()
+                    });
+                  }
+                }
+
+                if (rules.DirectiveCasing === `upper`) {
+                  if (value !== value.toUpperCase()) {
+                    errors.push({
+                      offset: { position: statement[0].range.start, end: statement[0].range.end },
+                      type: `DirectiveCasing`,
+                      newValue: value.toUpperCase()
                     });
                   }
                 }
@@ -319,7 +329,6 @@ export default class Linter {
                     });
                   }
                 }
-
                 break;
 
               case `declare`:

--- a/language/parserTypes.ts
+++ b/language/parserTypes.ts
@@ -41,7 +41,7 @@ export interface Rules {
   literalMinimum?: number;
   RequireBlankSpecial?: boolean;
   CopybookDirective?: "copy"|"include";
-  LowercaseDirectives?: boolean;
+  DirectiveCasing?: "lower"|"upper";
   UppercaseDirectives?: boolean;
   NoSQLJoins?: boolean;
   NoGlobalsInProcedures?: boolean;

--- a/language/parserTypes.ts
+++ b/language/parserTypes.ts
@@ -41,6 +41,7 @@ export interface Rules {
   literalMinimum?: number;
   RequireBlankSpecial?: boolean;
   CopybookDirective?: "copy"|"include";
+  LowercaseDirectives?: boolean;
   UppercaseDirectives?: boolean;
   NoSQLJoins?: boolean;
   NoGlobalsInProcedures?: boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-rpgle",
-	"version": "0.20.2",
+	"version": "0.24.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-rpgle",
-			"version": "0.20.2",
+			"version": "0.24.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {

--- a/schemas/rpglint.json
+++ b/schemas/rpglint.json
@@ -85,6 +85,11 @@
 			],
 			"description": "Force which directive which must be used to include other source. (Copy or Include)"
 		},
+		"LowercaseDirectives": {
+			"$id": "#/properties/LowercaseDirectives",
+			"type": "boolean",
+			"description": "Directives must be in lowercase."
+		},
 		"UppercaseDirectives": {
 			"$id": "#/properties/UppercaseDirectives",
 			"type": "boolean",

--- a/schemas/rpglint.json
+++ b/schemas/rpglint.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema",
+	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "https://github.com/halcyon-tech/vscode-ibmi",
 	"type": "object",
 	"description": "Available lint configuration for RPGLE",
@@ -97,7 +97,8 @@
 		"UppercaseDirectives": {
 			"$id": "#/properties/UppercaseDirectives",
 			"type": "boolean",
-			"description": "Directives must be in uppercase."
+			"description": "Directives must be in uppercase.",
+			"deprecated": true
 		},
 		"NoSQLJoins": {
 			"$id": "#/properties/NoSQLJoins",

--- a/schemas/rpglint.json
+++ b/schemas/rpglint.json
@@ -85,10 +85,14 @@
 			],
 			"description": "Force which directive which must be used to include other source. (Copy or Include)"
 		},
-		"LowercaseDirectives": {
-			"$id": "#/properties/LowercaseDirectives",
-			"type": "boolean",
-			"description": "Directives must be in lowercase."
+		"DirectiveCase": {
+			"$id": "#/properties/DirectiveCase",
+			"type": "string",
+			"enum": [
+				"lower",
+				"upper"
+			],
+			"description": "The expected casing of directives (lower or upper)."
 		},
 		"UppercaseDirectives": {
 			"$id": "#/properties/UppercaseDirectives",

--- a/tests/rpgle/copy3.rpgle
+++ b/tests/rpgle/copy3.rpgle
@@ -1,0 +1,3 @@
+**FREE
+
+Dcl-S CustomerName_t varchar(40) template;

--- a/tests/suite/directives.js
+++ b/tests/suite/directives.js
@@ -463,5 +463,111 @@ module.exports = {
     
     const someDs = cache.find(`someDs`);
     assert.strictEqual(someDs.keyword[`BASED`], undefined);
+  },
+
+  variable_case1: async () => {
+    const lines = [
+      `**FREE`,
+      `Ctl-Opt DftActGrp(*No);`,
+      `/copy './tests/rpgle/copy3.rpgle'`,
+      `Dcl-S MyCustomerName1 like(customername_t);`,
+      `Dcl-S MyCustomerName2 like(CustomerName_t);`,
+      `Dcl-S MyCustomerName3 like(CUSTOMERNAME_t);`,
+      `Dcl-S MyCustomerName4 like(CUSTOMERNAME_T);`,
+      `MyCustomerName1 = 'John Smith';`,
+      `dsply MyCustomerName1;`,
+      `Return;`
+    ].join(`\n`);
+
+    const cache = await parser.getDocs(uri, lines, {withIncludes: true, ignoreCache: true});
+    const { errors } = Linter.getErrors({ uri, content: lines }, {
+      IncorrectVariableCase: true
+    }, cache);
+
+    assert.strictEqual(errors.length, 3, `Expect length of 3`);
+
+    assert.deepStrictEqual(errors[0], {
+      offset: { position: 92, end: 106 },
+      type: `IncorrectVariableCase`,
+      newValue: `CustomerName_t`
+    });
+
+    assert.deepStrictEqual(errors[1], {
+      offset: { position: 180, end: 194 },
+      type: `IncorrectVariableCase`,
+      newValue: `CustomerName_t`
+    });
+
+    assert.deepStrictEqual(errors[2], {
+      offset: { position: 224, end: 238 },
+      type: `IncorrectVariableCase`,
+      newValue: `CustomerName_t`
+    });
+  },
+
+  uppercase1: async () => {
+    const lines = [
+      `**FREE`,
+      `Ctl-Opt DftActGrp(*No);`,
+      `/copy './tests/rpgle/copy1.rpgle'`,
+      `/Copy './tests/rpgle/copy2.rpgle'`,
+      `/COPY './tests/rpgle/copy3.rpgle'`,
+      `Dcl-S MyCustomerName1 like(CustomerName_t);`,
+      `MyCustomerName1 = 'John Smith';`,
+      `dsply MyCustomerName1;`,
+      `Return;`
+    ].join(`\n`);
+
+    const cache = await parser.getDocs(uri, lines, {withIncludes: true, ignoreCache: true});
+    const { errors } = Linter.getErrors({ uri, content: lines }, {
+      UppercaseDirectives: true
+    }, cache);
+
+    assert.strictEqual(errors.length, 2, `Expect length of 2`);
+
+    assert.deepStrictEqual(errors[0], {
+      offset: { position: 31, end: 36 },
+      type: `UppercaseDirectives`,
+      newValue: `/COPY`
+    });
+
+    assert.deepStrictEqual(errors[1], {
+      offset: { position: 65, end: 70 },
+      type: `UppercaseDirectives`,
+      newValue: `/COPY`
+    });
+  },
+
+  lowercase1: async () => {
+    const lines = [
+      `**FREE`,
+      `Ctl-Opt DftActGrp(*No);`,
+      `/copy './tests/rpgle/copy1.rpgle'`,
+      `/Copy './tests/rpgle/copy2.rpgle'`,
+      `/COPY './tests/rpgle/copy3.rpgle'`,
+      `Dcl-S MyCustomerName1 like(CustomerName_t);`,
+      `MyCustomerName1 = 'John Smith';`,
+      `dsply MyCustomerName1;`,
+      `Return;`
+    ].join(`\n`);
+
+    const cache = await parser.getDocs(uri, lines, {withIncludes: true, ignoreCache: true});
+    const { errors } = Linter.getErrors({ uri, content: lines }, {
+      LowercaseDirectives: true
+    }, cache);
+
+    assert.strictEqual(errors.length, 2, `Expect length of 2`);
+
+    assert.deepStrictEqual(errors[0], {
+      offset: { position: 65, end: 70 },
+      type: `LowercaseDirectives`,
+      newValue: `/copy`
+    });
+
+    assert.deepStrictEqual(errors[1], {
+      offset: { position: 99, end: 104 },
+      type: `LowercaseDirectives`,
+      newValue: `/copy`
+    });
   }
 }

--- a/tests/suite/directives.js
+++ b/tests/suite/directives.js
@@ -520,6 +520,39 @@ module.exports = {
 
     const cache = await parser.getDocs(uri, lines, {withIncludes: true, ignoreCache: true});
     const { errors } = Linter.getErrors({ uri, content: lines }, {
+      DirectiveCasing: `upper`
+    }, cache);
+
+    assert.strictEqual(errors.length, 2, `Expect length of 2`);
+
+    assert.deepStrictEqual(errors[0], {
+      offset: { position: 31, end: 36 },
+      type: `DirectiveCasing`,
+      newValue: `/COPY`
+    });
+
+    assert.deepStrictEqual(errors[1], {
+      offset: { position: 65, end: 70 },
+      type: `DirectiveCasing`,
+      newValue: `/COPY`
+    });
+  },
+
+  uppercase2: async () => {
+    const lines = [
+      `**FREE`,
+      `Ctl-Opt DftActGrp(*No);`,
+      `/copy './tests/rpgle/copy1.rpgle'`,
+      `/Copy './tests/rpgle/copy2.rpgle'`,
+      `/COPY './tests/rpgle/copy3.rpgle'`,
+      `Dcl-S MyCustomerName1 like(CustomerName_t);`,
+      `MyCustomerName1 = 'John Smith';`,
+      `dsply MyCustomerName1;`,
+      `Return;`
+    ].join(`\n`);
+
+    const cache = await parser.getDocs(uri, lines, {withIncludes: true, ignoreCache: true});
+    const { errors } = Linter.getErrors({ uri, content: lines }, {
       UppercaseDirectives: true
     }, cache);
 
@@ -553,20 +586,20 @@ module.exports = {
 
     const cache = await parser.getDocs(uri, lines, {withIncludes: true, ignoreCache: true});
     const { errors } = Linter.getErrors({ uri, content: lines }, {
-      LowercaseDirectives: true
+      DirectiveCasing: `lower`
     }, cache);
 
     assert.strictEqual(errors.length, 2, `Expect length of 2`);
 
     assert.deepStrictEqual(errors[0], {
       offset: { position: 65, end: 70 },
-      type: `LowercaseDirectives`,
+      type: `DirectiveCasing`,
       newValue: `/copy`
     });
 
     assert.deepStrictEqual(errors[1], {
       offset: { position: 99, end: 104 },
-      type: `LowercaseDirectives`,
+      type: `DirectiveCasing`,
       newValue: `/copy`
     });
   }

--- a/tests/suite/linter.js
+++ b/tests/suite/linter.js
@@ -1269,14 +1269,14 @@ exports.linter15 = async () => {
 
   assert.deepStrictEqual(errors[0], {
     offset: { position: 36, end: 38 },
-    type: 'PrettyComments',
-    newValue: '// '
+    type: `PrettyComments`,
+    newValue: `// `
   });
 
   assert.deepStrictEqual(errors[1], {
     offset: { position: 207, end: 209 },
-    type: 'PrettyComments',
-    newValue: '// '
+    type: `PrettyComments`,
+    newValue: `// `
   });
 };
 


### PR DESCRIPTION
### Changes

There is a linter rule for uppercase directives but not for lowercase directives, I like my directives to be in lowercase, so I've added a new LowercaseDirectives rule.

Whilst making this change I also corrected a couple of issues.
* Fix IncorrectVariableCase when definition exists in copybook, only noticed when using the Format Document option
* Fix Quick Fix comment for RequireBlankSpecial
* Added tests for IncorrectVariableCase, UppercaseDirectives, LowercaseDirectives

### Questions/Points

* Would it be better to have a single rule for the directive case such as `DirectivesCase: ['upper', lower']`? This would deprecate the existing `UppercaseDirectives` rule.
* Is there a way to actually run Quick Fixes as part of unit tests? One of the fixes I implemented only occurred when the Format Document option was run.
* I'll update the docs once I know the pull request is acceptable.
* I initially tried using `npm run test` to run the test suite but this failed with a module not found error. I'm pretty sure this is because the typescript needs to be compiled before the tests are run but I couldn't work out how this be done so used the 'Debug Tests' from the VS Code debugger instead.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in the README
