### PR TITLE
Refactor subroutine under new Code Action

### DIFF
--- a/extension/server/src/providers/linter/codeActions.ts
+++ b/extension/server/src/providers/linter/codeActions.ts
@@ -1,5 +1,5 @@
 import { CodeAction, CodeActionKind, CodeActionParams, Range } from 'vscode-languageserver';
-import { getActions, getExtractProcedureAction, refreshLinterDiagnostics } from '.';
+import { getActions, getExtractProcedureAction, getSubroutineActions, refreshLinterDiagnostics } from '.';
 import { documents, parser } from '..';
 
 export default async function codeActionsProvider(params: CodeActionParams): Promise<CodeAction[]|undefined> {
@@ -13,6 +13,11 @@ export default async function codeActionsProvider(params: CodeActionParams): Pro
 			const docs = await parser.getDocs(document.uri);
 
 			if (docs) {
+				const subroutineOption = getSubroutineActions(document, docs, range);
+				if (subroutineOption) {
+					return [subroutineOption];
+				}
+
 				const extractOption = getExtractProcedureAction(document, docs, range);
 				if (extractOption) {
 					return [extractOption];

--- a/extension/server/src/providers/linter/index.ts
+++ b/extension/server/src/providers/linter/index.ts
@@ -459,7 +459,7 @@ export function getSubroutineActions(document: TextDocument, docs: Cache, range:
 					  ...extracted.references.map((ref, i) => `    ${extracted.newParamNames[i]} ${ref.dec.type === `struct` ? `LikeDS` : `Like`}(${ref.dec.name});`),
 				`  End-Pi;`,
 				``,
-				extracted.newBody,
+				caseInsensitiveReplaceAll(extracted.newBody, `leavesr`, `return`),
 				`End-Proc;`
 			].join(`\n`)
 
@@ -531,6 +531,11 @@ export function getExtractProcedureAction(document: TextDocument, docs: Cache, r
 			return newAction;
 	}
 }
+
+function caseInsensitiveReplaceAll(text: string, search: string, replace: string) {
+	return text.replace(new RegExp(search, `gi`), replace);
+}
+	
 
 function createExtract(document: TextDocument, userRange: Range, docs: Cache) {
 	const range = Range.create(userRange.start.line, 0, userRange.end.line, 1000);

--- a/language/linter.ts
+++ b/language/linter.ts
@@ -387,8 +387,7 @@ export default class Linter {
                       if (rules.NoGlobalSubroutines) {
                         errors.push({
                           offset: { position: statement[0].range.start, end: statement[0].range.end },
-                          type: `NoGlobalSubroutines`,
-                          newValue: `Dcl-Proc`
+                          type: `NoGlobalSubroutines`
                         });
                       }
                     }
@@ -584,8 +583,7 @@ export default class Linter {
                       if (rules.NoGlobalSubroutines) {
                         errors.push({
                           offset: { position: statement[0].range.start, end: statement[0].range.end },
-                          type: `NoGlobalSubroutines`,
-                          newValue: `End-Proc`
+                          type: `NoGlobalSubroutines`
                         });
                       }
                     }
@@ -661,8 +659,7 @@ export default class Linter {
                     if (rules.NoGlobalSubroutines && !inProcedure) {
                       errors.push({
                         type: `NoGlobalSubroutines`,
-                        offset: { position: statement[0].range.start, end: statement[statement.length - 1].range.end },
-                        newValue: `return`
+                        offset: { position: statement[0].range.start, end: statement[statement.length - 1].range.end }
                       });
                     }
                     break;
@@ -672,8 +669,7 @@ export default class Linter {
                         if (globalScope.subroutines.find(sub => sub.name.toUpperCase() === statement[1].value.toUpperCase())) {
                           errors.push({
                             type: `NoGlobalSubroutines`,
-                            offset: { position: statement[0].range.start, end: statement[statement.length - 1].range.end },
-                            newValue: `${statement[1].value}()`
+                            offset: { position: statement[0].range.start, end: statement[statement.length - 1].range.end }
                           });
                         }
                       }

--- a/tests/suite/linter.js
+++ b/tests/suite/linter.js
@@ -1305,20 +1305,17 @@ exports.linter16 = async () => {
 
   assert.deepStrictEqual(errors[0], {
     type: `NoGlobalSubroutines`,
-    offset: { position: 36, end: 54 },
-    newValue: `theSubroutine()`
+    offset: { position: 36, end: 54 }
   });
 
   assert.deepStrictEqual(errors[1], {
     offset: { position: 76, end: 81 },
-    type: `NoGlobalSubroutines`,
-    newValue: `Dcl-Proc`
+    type: `NoGlobalSubroutines`
   });
 
   assert.deepStrictEqual(errors[2], {
     offset: { position: 128, end: 133 },
-    type: `NoGlobalSubroutines`,
-    newValue: `End-Proc`
+    type: `NoGlobalSubroutines`
   });
 };
 
@@ -1349,26 +1346,22 @@ exports.linter16_with_leavesr = async () => {
 
   assert.deepStrictEqual(errors[0], {
     type: `NoGlobalSubroutines`,
-    offset: { position: 71, end: 89 },
-    newValue: `theSubroutine()`
+    offset: { position: 71, end: 89 }
   });
 
   assert.deepStrictEqual(errors[1], {
     offset: { position: 111, end: 116 },
-    type: `NoGlobalSubroutines`,
-    newValue: `Dcl-Proc`
+    type: `NoGlobalSubroutines`
   });
 
   assert.deepStrictEqual(errors[2], {
     type: `NoGlobalSubroutines`,
-    offset: { position: 156, end: 163 },
-    newValue: `return`
+    offset: { position: 156, end: 163 }
   });
 
   assert.deepStrictEqual(errors[3], {
     offset: { position: 205, end: 210 },
-    type: `NoGlobalSubroutines`,
-    newValue: `End-Proc`
+    type: `NoGlobalSubroutines`
   });
 };
 


### PR DESCRIPTION
Previously, the cleanup of subroutines could only be done when the linter was enabled.

Now the linter will still complain about subroutines, but we provide a new Code Action, similar to extract to procedure, but for subroutines. It will convert the subroutine to a procedure and create parameters for references variables of certain types.

<img width="1414" alt="image" src="https://github.com/codefori/vscode-rpgle/assets/3708366/a871ddf4-7af8-46e3-a1fd-d7df0636b6c4">
