### PR TITLE
Removed QUALIFIED for EXTNAME. Fix QUALIFIED on LIKEREC/LIKEDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 - [@chrjorgensen](https://github.com/chrjorgensen)
 - [@sebjulliand](https://github.com/sebjulliand)
 - [@richardm90](https://github.com/richardm90)
+- [@wright4i](https://github.com/wright4i)

--- a/language/parser.js
+++ b/language/parser.js
@@ -276,9 +276,6 @@ export default class Parser {
           }
 
           if ([`EXTNAME`].includes(tag)) {
-            if (!ds.keywords.includes(`QUALIFIED`))
-              ds.keywords.push(`QUALIFIED`);
-
             // Fetch from external definitions
             const recordFormats = await this.fetchTable(keywordValue, ds.keywords.length.toString(), ds.keywords.includes(`ALIAS`));
 
@@ -298,15 +295,15 @@ export default class Parser {
             }
 
           } else {
+            // We need to add qualified as it is qualified by default.
+            if (!ds.keywords.includes(`QUALIFIED`))
+            ds.keywords.push(`QUALIFIED`);
+
             // Fetch from local definitions
             for (let i = scopes.length - 1; i >= 0; i--) {
               const valuePointer = scopes[i].structs.find(struct => struct.name.toUpperCase() === keywordValue);
               if (valuePointer) {
                 ds.subItems = valuePointer.subItems;
-    
-                // We need to add qualified as it is qualified by default.
-                if (!ds.keywords.includes(`QUALIFIED`))
-                  ds.keywords.push(`QUALIFIED`);
                 return;
               }
             }


### PR DESCRIPTION
### Changes

Fix for issue #299

- EXTNAME no longer shows `QUALIFIED`
- LIKEREC and LIKEDS prior to change were not showing `QUALIFIED` as originally intended (because they're qualified by default). They now do.

![image](https://github.com/codefori/vscode-rpgle/assets/93156666/608fd6d5-572b-4fc1-a6ec-9c69dcfac455)
![image](https://github.com/codefori/vscode-rpgle/assets/93156666/2ce081c3-7f4c-48da-bba0-d5bf42991c62)
![image](https://github.com/codefori/vscode-rpgle/assets/93156666/89f28c2d-23c3-4600-879e-6840a1be5db2)

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
