### PR TITLE
Turn off tools based on environment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,11 +26,3 @@ jobs:
       - name: Publish to Open VSX
         run: npx ovsx publish -p ${{ secrets.OPENVSX_TOKEN }}
         
-      # Create linter only build
-      - name: Create linter only build (Merlin)
-        run: npm run package:linter
-      - name: Upload build
-        uses: actions/upload-artifact@v2
-        with:
-          name: vscode-rpgle-linter-only
-          path: ./*.vsix

--- a/extension/server/src/data.ts
+++ b/extension/server/src/data.ts
@@ -1,6 +1,11 @@
 import Declaration from '../../../language/models/declaration';
 import { getPrettyType } from '../../../language/models/fixed';
 
+export function isInMerlin(): boolean {
+	const { MACHINE_EXEC_PORT } = process.env;
+	return MACHINE_EXEC_PORT !== undefined;
+}
+
 export function parseMemberUri(path: string): {asp?: string, library?: string, file?: string, name: string} {
 	const parts = path.split(`/`).map(s => s.split(`,`)).flat().filter(s => s.length >= 1);
 	return {

--- a/extension/server/src/server.ts
+++ b/extension/server/src/server.ts
@@ -26,7 +26,7 @@ import { getPrettyType } from '../../../language/models/fixed';
 import * as Project from './providers/project';
 import workspaceSymbolProvider from './providers/project/workspaceSymbol';
 import implementationProvider from './providers/implementation';
-import { dspffdToRecordFormats, parseMemberUri } from './data';
+import { dspffdToRecordFormats, isInMerlin, parseMemberUri } from './data';
 import path = require('path');
 import { existsSync } from 'fs';
 import { renamePrepareProvider, renameRequestProvider } from './providers/rename';
@@ -35,9 +35,11 @@ let hasConfigurationCapability = false;
 let hasWorkspaceFolderCapability = false;
 let hasDiagnosticRelatedInformationCapability = false;
 
-const languageToolsEnabled = process.env.LANGUAGE_TOOLS_ENABLED;
-const linterEnabled = process.env.LINTER_ENABLED;
-const formatterEnabled = process.env.FORMATTER_ENABLED;
+const outsideMerlin = !isInMerlin();
+
+const languageToolsEnabled = outsideMerlin;
+const linterEnabled = true;
+const formatterEnabled = outsideMerlin;
 
 let projectEnabled = false;
 

--- a/extension/server/webpack.config.js
+++ b/extension/server/webpack.config.js
@@ -20,11 +20,4 @@ module.exports = withDefaults({
     filename: `server.js`,
     path: path.join(__dirname, `..`, `..`, `out`)
   },
-  plugins: [
-    new webpack.DefinePlugin({
-      'process.env.LANGUAGE_TOOLS_ENABLED': process.env.LANGUAGE_TOOLS_ENABLED || `true`,
-      'process.env.LINTER_ENABLED': process.env.LINTER_ENABLED || `true`,
-      'process.env.FORMATTER_ENABLED': process.env.FORMATTER_ENABLED || `true`,
-    }),
-  ],
 });

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"package": "vsce package",
-		"package:linter": "LANGUAGE_TOOLS_ENABLED=\"false\" FORMATTER_ENABLED=\"false\" vsce package",
 		"vscode:prepublish": "npm run webpack",
 		"webpack": "npm run clean && webpack --mode production --config ./extension/client/webpack.config.js && webpack --mode production --config ./extension/server/webpack.config.js",
 		"webpack:dev": "npm run clean && webpack --mode none --config ./extension/client/webpack.config.js && webpack --mode none --config ./extension/server/webpack.config.js",


### PR DESCRIPTION
### Changes

Disables the language tools based on environment rather than build.

### Checklist

* [x] have tested my change. **Continues to work in VS Code as normal**
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
