### PR TITLE
Add snippets for %HIVAL and %LOVAL

### DIFF
--- a/schemas/rpgle.code-snippets
+++ b/schemas/rpgle.code-snippets
@@ -561,6 +561,13 @@
 		],
 		"description": "%HANDLER is used to identify a procedure to handle an event or a series of events. %HANDLER does not return a value, and it can only be specified as the first operand of XML-SAX, XML-INTO and DATA-INTO."
 	},
+	"%hival": {
+		"prefix": "%hival",
+		"body": [
+			"%hival(${1:variable or enum})"
+		],
+		"description": "%HIVAL returns the highest possible value of a variable or the highest value in an enumeration."
+	},
 	"%hours": {
 		"prefix": "%hours",
 		"body": [
@@ -651,6 +658,13 @@
 			"%lookupge(${1:argument} :${2:array} :${3:(optional) start index} :${4:(optional) number of elements})"
 		],
 		"description": "%LOOKUPGE returns the array index of the item in the array that is an exact match, or the value that is closest to argument but greater than argument."
+	},
+	"%loval": {
+		"prefix": "%loval",
+		"body": [
+			"%loval(${1:variable or enum})"
+		],
+		"description": "%LOVAL returns the lowest possible value of a variable or the lowest value in an enumeration."
 	},
 	"%lower": {
 		"prefix": "%lower",


### PR DESCRIPTION
### Changes

This PR will add snippets for new BIF's %HIVAL and %LOVAL, introduced in Fall 2024 RPGLE enhancements.
For more information, see [this link](https://www.ibm.com/support/pages/node/7172133).

### Checklist

* [x] have tested my change
* [x] **for feature PRs**: PR only includes one feature enhancement.
