### PR TITLE
Refactor keyword handling in language server

### DIFF
--- a/extension/server/src/data.ts
+++ b/extension/server/src/data.ts
@@ -46,16 +46,16 @@ export function dspffdToRecordFormats(data: any, aliases = false): Declaration[]
 
 		const currentSubfield = new Declaration(`subitem`);
 		currentSubfield.name = name;
-		const keywords = [];
+		let keywords: {[key: string]: string|true} = {};
 
-		if (row.WHVARL === `Y`) keywords.push(`VARYING`);
+		if (row.WHVARL === `Y`) keywords[`VARYING`] = true;
 
-		currentSubfield.keywords = [getPrettyType({
+		currentSubfield.keyword = getPrettyType({
 			type,
 			len: digits === 0 ? strLength : digits,
 			decimals: decimals,
 			keywords,
-		})];
+		});
 		currentSubfield.description = text.trim();
 
 		recordFormat.subItems.push(currentSubfield);

--- a/extension/server/src/providers/completionItem.ts
+++ b/extension/server/src/providers/completionItem.ts
@@ -1,6 +1,6 @@
 import path = require('path');
 import { CompletionItem, CompletionItemKind, CompletionParams, InsertTextFormat, Position, Range } from 'vscode-languageserver';
-import { documents, getWordRangeAtPosition, parser } from '.';
+import { documents, getWordRangeAtPosition, parser, prettyKeywords } from '.';
 import Cache from '../../../../language/models/cache';
 import Declaration from '../../../../language/models/declaration';
 import * as ileExports from './apis';
@@ -78,7 +78,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 							const item = CompletionItem.create(subItem.name);
 							item.kind = CompletionItemKind.Property;
 							item.insertText = subItem.name;
-							item.detail = subItem.keywords.join(` `);
+							item.detail = prettyKeywords(subItem.keyword);
 							item.documentation = subItem.description + `${possibleStruct ? ` (${possibleStruct.name})` : ``}`;
 							return item;
 						}));
@@ -109,7 +109,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 							const item = CompletionItem.create(`${subItem.name}`);
 							item.kind = CompletionItemKind.TypeParameter;
 							item.insertText = subItem.name;
-							item.detail = [`parameter`, ...subItem.keywords].join(` `);
+							item.detail = [`parameter`, prettyKeywords(subItem.keyword)].join(` `);
 							item.documentation = subItem.description;
 							items.push(item);
 						}
@@ -119,7 +119,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 							item.kind = CompletionItemKind.Function;
 							item.insertTextFormat = InsertTextFormat.Snippet;
 							item.insertText = `${procedure.name}(${procedure.subItems.map((parm, index) => `\${${index + 1}:${parm.name}}`).join(`:`)})`;
-							item.detail = procedure.keywords.join(` `);
+							item.detail = prettyKeywords(procedure.keyword);
 							item.documentation = procedure.description;
 							items.push(item);
 						}
@@ -136,7 +136,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 							const item = CompletionItem.create(`${variable.name}`);
 							item.kind = CompletionItemKind.Variable;
 							item.insertText = `${variable.name}`;
-							item.detail = variable.keywords.join(` `);
+							item.detail = prettyKeywords(variable.keyword);
 							item.documentation = variable.description;
 							items.push(item);
 						}
@@ -145,7 +145,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 							const item = CompletionItem.create(`${file.name}`);
 							item.kind = CompletionItemKind.File;
 							item.insertText = `${file.name}`;
-							item.detail = file.keywords.join(` `);
+							item.detail = prettyKeywords(file.keyword);
 							item.documentation = file.description;
 							items.push(item);
 
@@ -153,7 +153,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 								const item = CompletionItem.create(`${struct.name}`);
 								item.kind = CompletionItemKind.Struct;
 								item.insertText = `${struct.name}`;
-								item.detail = struct.keywords.join(` `);
+								item.detail = prettyKeywords(struct.keyword);
 								item.documentation = struct.description;
 								items.push(item);
 
@@ -162,7 +162,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 										const item = CompletionItem.create(`${subItem.name}`);
 										item.kind = CompletionItemKind.Property;
 										item.insertText = `${subItem.name}`;
-										item.detail = subItem.keywords.join(` `);
+										item.detail = prettyKeywords(subItem.keyword);
 										item.documentation = subItem.description + ` (${struct.name})`;
 										items.push(item);
 									});
@@ -174,7 +174,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 							const item = CompletionItem.create(`${struct.name}`);
 							item.kind = CompletionItemKind.Struct;
 							item.insertText = `${struct.name}`;
-							item.detail = struct.keywords.join(` `);
+							item.detail = prettyKeywords(struct.keyword);
 							item.documentation = struct.description;
 							items.push(item);
 
@@ -183,7 +183,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 									const item = CompletionItem.create(`${subItem.name}`);
 									item.kind = CompletionItemKind.Property;
 									item.insertText = `${subItem.name}`;
-									item.detail = subItem.keywords.join(` `);
+									item.detail = prettyKeywords(subItem.keyword);
 									item.documentation = subItem.description + ` (${struct.name})`;
 									items.push(item);
 								});
@@ -194,7 +194,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 							const item = CompletionItem.create(`${constant.name}`);
 							item.kind = CompletionItemKind.Constant;
 							item.insertText = `${constant.name}`;
-							item.detail = constant.keywords.join(` `);
+							item.detail = prettyKeywords(constant.keyword);
 							item.documentation = constant.description;
 							items.push(item);
 
@@ -203,7 +203,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 									const item = CompletionItem.create(`${subItem.name}`);
 									item.kind = CompletionItemKind.Property;
 									item.insertText = `${subItem.name}`;
-									item.detail = subItem.keywords.join(` `);
+									item.detail = prettyKeywords(subItem.keyword);
 									item.documentation = subItem.description + ` (${constant.name})`;
 									items.push(item);
 								});
@@ -226,7 +226,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 								const item = CompletionItem.create(`${subItem.name}`);
 								item.kind = CompletionItemKind.TypeParameter;
 								item.insertText = subItem.name;
-								item.detail = [`parameter`, ...subItem.keywords].join(` `);
+								item.detail = [`parameter`, prettyKeywords(subItem.keyword)].join(` `);
 								item.documentation = subItem.description;
 								items.push(item);
 							}

--- a/extension/server/src/providers/documentSymbols.ts
+++ b/extension/server/src/providers/documentSymbols.ts
@@ -1,5 +1,5 @@
 import { DocumentSymbol, DocumentSymbolParams, Range, SymbolKind } from 'vscode-languageserver';
-import { documents, parser } from '.';
+import { documents, parser, prettyKeywords } from '.';
 import Cache from '../../../../language/models/cache';
 
 export default async function documentSymbolProvider(handler: DocumentSymbolParams): Promise<DocumentSymbol[]> {
@@ -22,7 +22,7 @@ export default async function documentSymbolProvider(handler: DocumentSymbolPara
 				.forEach(proc => {
 					const procDef = DocumentSymbol.create(
 						proc.name,
-						proc.keywords.join(` `).trim(),
+						prettyKeywords(proc.keyword),
 						SymbolKind.Function,
 						Range.create(proc.range.start, 0, proc.range.end, 0),
 						Range.create(proc.range.start, 0, proc.range.start, 0),
@@ -33,7 +33,7 @@ export default async function documentSymbolProvider(handler: DocumentSymbolPara
 						.filter(subitem => subitem.position && subitem.position.path === currentPath)
 						.map(subitem => DocumentSymbol.create(
 							subitem.name,
-							subitem.keywords.join(` `).trim(),
+							prettyKeywords(subitem.keyword),
 							SymbolKind.Property,
 							Range.create(subitem.position.line, 0, subitem.position.line, 0),
 							Range.create(subitem.position.line, 0, subitem.position.line, 0)
@@ -50,7 +50,7 @@ export default async function documentSymbolProvider(handler: DocumentSymbolPara
 					.filter(def => def.range.start)
 					.map(def => DocumentSymbol.create(
 						def.name,
-						def.keywords.join(` `).trim(),
+						prettyKeywords(def.keyword),
 						SymbolKind.Function,
 						Range.create(def.range.start, 0, def.range.end, 0),
 						Range.create(def.range.start, 0, def.range.start, 0),
@@ -60,7 +60,7 @@ export default async function documentSymbolProvider(handler: DocumentSymbolPara
 					.filter(variable => variable.position && variable.position.path === currentPath)
 					.map(def => DocumentSymbol.create(
 						def.name,
-						def.keywords.join(` `).trim(),
+						prettyKeywords(def.keyword),
 						SymbolKind.Variable,
 						Range.create(def.position.line, 0, def.position.line, 0),
 						Range.create(def.position.line, 0, def.position.line, 0)
@@ -72,7 +72,7 @@ export default async function documentSymbolProvider(handler: DocumentSymbolPara
 				.forEach(def => {
 					const constantDef = DocumentSymbol.create(
 						def.name,
-						def.keywords.join(` `).trim(),
+						prettyKeywords(def.keyword),
 						SymbolKind.Constant,
 						Range.create(def.position.line, 0, def.position.line, 0),
 						Range.create(def.position.line, 0, def.position.line, 0)
@@ -83,7 +83,7 @@ export default async function documentSymbolProvider(handler: DocumentSymbolPara
 							.filter(subitem => subitem.position && subitem.position.path === currentPath)
 							.map(subitem => DocumentSymbol.create(
 								subitem.name,
-								subitem.keywords.join(` `).trim(),
+								prettyKeywords(subitem.keyword),
 								SymbolKind.Property,
 								Range.create(subitem.position.line, 0, subitem.position.line, 0),
 								Range.create(subitem.position.line, 0, subitem.position.line, 0)
@@ -98,7 +98,7 @@ export default async function documentSymbolProvider(handler: DocumentSymbolPara
 				.forEach(file => {
 					const fileDef = DocumentSymbol.create(
 						file.name,
-						file.keywords.join(` `).trim(),
+						prettyKeywords(file.keyword),
 						SymbolKind.File,
 						Range.create(file.position.line, 0, file.position.line, 0),
 						Range.create(file.position.line, 0, file.position.line, 0)
@@ -111,7 +111,7 @@ export default async function documentSymbolProvider(handler: DocumentSymbolPara
 						.forEach(recordFormat => {
 							const recordFormatDef = DocumentSymbol.create(
 								recordFormat.name,
-								recordFormat.keywords.join(` `).trim(),
+								prettyKeywords(recordFormat.keyword),
 								SymbolKind.Struct,
 								Range.create(recordFormat.position.line, 0, recordFormat.position.line, 0),
 								Range.create(recordFormat.position.line, 0, recordFormat.position.line, 0)
@@ -121,7 +121,7 @@ export default async function documentSymbolProvider(handler: DocumentSymbolPara
 								.filter(subitem => subitem.position && subitem.position.path === currentPath)
 								.map(subitem => DocumentSymbol.create(
 									subitem.name,
-									subitem.keywords.join(` `).trim(),
+									prettyKeywords(subitem.keyword),
 									SymbolKind.Property,
 									Range.create(subitem.position.line, 0, subitem.position.line, 0),
 									Range.create(subitem.position.line, 0, subitem.position.line, 0)
@@ -140,7 +140,7 @@ export default async function documentSymbolProvider(handler: DocumentSymbolPara
 				.forEach(struct => {
 					const structDef = DocumentSymbol.create(
 						struct.name,
-						struct.keywords.join(` `).trim(),
+						prettyKeywords(struct.keyword),
 						SymbolKind.Struct,
 						Range.create(struct.range.start, 0, struct.range.end, 0),
 						Range.create(struct.range.start, 0, struct.range.start, 0),
@@ -150,7 +150,7 @@ export default async function documentSymbolProvider(handler: DocumentSymbolPara
 						.filter(subitem => subitem.position && subitem.position.path === currentPath)
 						.map(subitem => DocumentSymbol.create(
 							subitem.name,
-							subitem.keywords.join(` `).trim(),
+							prettyKeywords(subitem.keyword),
 							SymbolKind.Property,
 							Range.create(subitem.position.line, 0, subitem.position.line, 0),
 							Range.create(subitem.position.line, 0, subitem.position.line, 0)

--- a/extension/server/src/providers/index.ts
+++ b/extension/server/src/providers/index.ts
@@ -11,6 +11,8 @@ import {
 } from 'vscode-languageserver-textdocument';
 import Parser from '../../../../language/parser';
 
+type Keywords = {[key: string]: string | boolean};
+
 // Create a simple text document manager.
 export const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
 
@@ -40,4 +42,18 @@ export function getWordRangeAtPosition(document: TextDocument, position: Positio
 		return undefined;
 	else
 		return document.getText(Range.create(line, Math.max(0, startChar), line, endChar+1)).replace(/(\r\n|\n|\r)/gm, "");
+}
+
+export function prettyKeywords(keywords: Keywords): string {
+	return Object.keys(keywords).map(key => {
+		if (keywords[key] ) {
+			if (typeof keywords[key] === `boolean`) {
+				return key.toLowerCase();
+			}
+
+			return `${key.toLowerCase()}(${keywords[key]})`;
+		} else {
+			return undefined;
+		}
+	}).filter(k => k).join(` `);
 }

--- a/extension/server/src/providers/project/exportInterfaces.ts
+++ b/extension/server/src/providers/project/exportInterfaces.ts
@@ -1,7 +1,7 @@
 import path = require('path');
 import { APIInterface } from '../apis';
 import { isEnabled } from '.';
-import { parser } from '..';
+import { parser, prettyKeywords } from '..';
 
 export function getInterfaces(): APIInterface[] {
 	let interfaces: APIInterface[] = [];
@@ -30,16 +30,13 @@ export function getInterfaces(): APIInterface[] {
 
 							if (entryFunction) {
 
-								let keywords = entryFunction.keywords
-									.map(keyword => keyword.toLowerCase());
-
 								// We assume the file name is the name of the object
-								keywords.push(`extpgm('${objectName}')`);
+								entryFunction.keyword[`EXTPGM`] = `'${objectName}'`;
 
 								const prototype = [
-									`dcl-pr ${entryFunction.name} ${keywords.join(` `)};`,
+									`dcl-pr ${entryFunction.name} ${prettyKeywords(entryFunction.keyword)};`,
 									...entryFunction.subItems.map(subItem =>
-										`  ${subItem.name} ${subItem.keywords.map(keyword => keyword.toLowerCase()).join(` `)};`
+										`  ${subItem.name} ${prettyKeywords(subItem.keyword)};`
 									),
 									`end-pr;`
 								];
@@ -60,16 +57,13 @@ export function getInterfaces(): APIInterface[] {
 						// This might mean it is a module. Look for EXPORTs
 						cache.procedures.forEach(proc => {
 							if (proc.keyword[`EXPORT`]) {
-								let keywords = proc.keywords
-									.map(keyword => keyword.toLowerCase())
-									.filter(keyword => keyword !== `export`);
 
-								keywords.push(`extproc('${proc.name.toUpperCase()}')`);
+								proc.keyword[`EXTPROC`] = `'${proc.name.toUpperCase()}'`;
 
 								const prototype = [
-									`dcl-pr ${proc.name} ${keywords.join(` `)};`,
+									`dcl-pr ${proc.name} ${prettyKeywords(proc.keyword)};`,
 									...proc.subItems.map(subItem =>
-										`  ${subItem.name} ${subItem.keywords.map(keyword => keyword.toLowerCase()).join(` `)};`
+										`  ${subItem.name} ${prettyKeywords(subItem.keyword)};`
 									),
 									`end-pr;`
 								];

--- a/language/models/declaration.js
+++ b/language/models/declaration.js
@@ -10,9 +10,6 @@ export default class Declaration {
     this.type = type;
     this.name = ``;
 
-    /** @type {string[]} */
-    this.keywords = [];
-
     /** @type {import("../parserTypes").Keywords} */
     this.keyword = {};
     
@@ -49,7 +46,7 @@ export default class Declaration {
   clone() {
     const clone = new Declaration(this.type);
     clone.name = this.name;
-    clone.keywords = [...this.keywords];
+    clone.keyword = this.keyword;
     clone.description = this.description;
     clone.tags = this.tags;
 

--- a/language/models/fixed.js
+++ b/language/models/fixed.js
@@ -1,3 +1,4 @@
+import Parser from "../parser";
 
 /**
  * @param {string} line 
@@ -8,11 +9,10 @@ export function parseFLine(line) {
   // const field = line.substr(33, 1).toUpperCase(); //KEYED
   // const device = line.substr(35, 7).toUpperCase().trim(); //device: DISK, WORKSTN
   const keywords = line.substr(43).trim();
-  const splitKeywords = keywords.split(` `).filter(word => word !== ``);
 
   return {
     name, 
-    keywords: splitKeywords
+    keywords: Parser.expandKeywords(keywords)
   };
 }
 
@@ -56,7 +56,6 @@ export function parseDLine(line) {
   const decimals = line.substr(40, 3).trim();
   const field = line.substr(23, 2).trim().toUpperCase();
   const keywords = line.substr(43).trim().toUpperCase();
-  const splitKeywords = keywords.split(` `).filter(word => word !== ``);
 
   return {
     potentialName,
@@ -66,7 +65,7 @@ export function parseDLine(line) {
     type,
     decimals,
     field,
-    keywords: splitKeywords
+    keywords: Parser.expandKeywords(keywords)
   };
 }
 
@@ -79,20 +78,19 @@ export function parsePLine(line) {
   const potentialName = line.substring(6).trim();
   const start = line[23].toUpperCase() === `B`;
   const keywords = line.substr(43).trim().toUpperCase();
-  const splitKeywords = keywords.split(` `).filter(word => word !== ``);
 
   return {
     name,
     potentialName,
-    keywords: splitKeywords,
+    keywords: Parser.expandKeywords(keywords),
     start
   };
 }
 
 /**
  * 
- * @param {{type: string, keywords: string[], len: string, pos?: string, decimals?: string, field?: string}} lineData 
- * @returns {string}
+ * @param {{type: string, keywords: import("../parserTypes").Keywords, len: string, pos?: string, decimals?: string, field?: string}} lineData 
+ * @returns {import("../parserTypes").Keywords}
  */
 export function getPrettyType(lineData) {
   let outType = ``;
@@ -104,7 +102,7 @@ export function getPrettyType(lineData) {
 
   switch (lineData.type.toUpperCase()) {
   case `A`:
-    if (lineData.keywords.indexOf(`VARYING`) >= 0) {
+    if (Number(lineData.keywords[`VARYING`]) >= 0) {
       outType = `Varchar`;
 	  // For VARCHAR, the field defined will have a 2-byte integer field appended to the beginning of it that will contain the length of the data that is valid in the data portion of the field
       length -= 2;			  
@@ -140,7 +138,7 @@ export function getPrettyType(lineData) {
     outType = `Float` + `(` + lineData.len + `)`;
     break;
   case `G`:
-    if (lineData.keywords.indexOf(`VARYING`) >= 0) {
+    if (Number(lineData.keywords[`VARYING`]) >= 0) {
       outType = `Vargraph`;
     } else {
       outType = `Graph`;
@@ -207,7 +205,7 @@ export function getPrettyType(lineData) {
       outType = `lineData.Len(` + lineData.len + `)`;
     } else if (lineData.len != ``) {
       if (lineData.decimals == ``) {
-        if (lineData.keywords.indexOf(`VARYING`) >= 0) {
+        if (Number(lineData.keywords[`VARYING`]) >= 0) {
           outType = `Varchar`;
         } else {
           outType = `Char`;
@@ -226,5 +224,5 @@ export function getPrettyType(lineData) {
     break;
   }
 
-  return outType.toUpperCase();
+  return Parser.expandKeywords(outType);
 }

--- a/language/tokens.ts
+++ b/language/tokens.ts
@@ -258,8 +258,7 @@ const endCommentString = `\n`;
  * @param {string} statement 
  * @returns {{value?: string, block?: object[], type: string, position: number}[]}
  */
-export function tokenise(statement) {
-  let lineNumber = 0;
+export function tokenise(statement, lineNumber = 0) {
   let commentStart = -1;
   let state: ReadState = ReadState.NORMAL;
 

--- a/language/tokens.ts
+++ b/language/tokens.ts
@@ -59,7 +59,7 @@ const commonMatchers: Matcher[] = [
       { type: `asterisk` },
       {
         type: `word`, match: (word) =>
-          [`CTDATA`, `BLANK`, `BLANKS`, `ZERO`, `ZEROS`, `ON`, `OFF`, `NULL`, `ISO`, `MDY`, `DMY`, `EUR`, `YMD`, `USA`, `SECONDS`, `S`, `MINUTES`, `MN`, `HOURS`, `H`, `DAYS`, `D`, `MONTHS`, `M`, `YEARS`, `Y`, `HIVAL`, `END`, `LOVAL`, `START`, `N`, `OMIT`, `STRING`, `CWIDEN`, `CONVERT`].includes(word.toUpperCase()) || word.toUpperCase().startsWith(`IN`)
+          [`PSSR`, `CTDATA`, `BLANK`, `BLANKS`, `ZERO`, `ZEROS`, `ON`, `OFF`, `NULL`, `ISO`, `MDY`, `DMY`, `EUR`, `YMD`, `USA`, `SECONDS`, `S`, `MINUTES`, `MN`, `HOURS`, `H`, `DAYS`, `D`, `MONTHS`, `M`, `YEARS`, `Y`, `HIVAL`, `END`, `LOVAL`, `START`, `N`, `OMIT`, `STRING`, `CWIDEN`, `CONVERT`].includes(word.toUpperCase()) || word.toUpperCase().startsWith(`IN`)
       }
     ],
     becomes: {

--- a/tests/suite/basics.test.ts
+++ b/tests/suite/basics.test.ts
@@ -1222,7 +1222,6 @@ test(`exec_14`, async () => {
 
   const cache = await parser.getDocs(uri, lines, {withIncludes: true, ignoreCache: true});
 
-  console.log(cache.sqlReferences);
   expect(cache.sqlReferences.length).toBe(1);
   expect(cache.sqlReferences[0].name).toBe(`table1`);
 });

--- a/tests/suite/basics.test.ts
+++ b/tests/suite/basics.test.ts
@@ -619,7 +619,7 @@ test('inline_end_pi', async () => {
 
   const getHandle = cache.find(`getHandle`);
 
-  expect(getHandle.keyword[`LIKE`]).toBe(`HANDLE_T`);
+  expect(getHandle.keyword[`LIKE`]).toBe(`handle_t`);
   expect(getHandle.keyword[`END-PI`]).toBeUndefined();
 });
 
@@ -1222,6 +1222,7 @@ test(`exec_14`, async () => {
 
   const cache = await parser.getDocs(uri, lines, {withIncludes: true, ignoreCache: true});
 
+  console.log(cache.sqlReferences);
   expect(cache.sqlReferences.length).toBe(1);
   expect(cache.sqlReferences[0].name).toBe(`table1`);
 });
@@ -1293,8 +1294,8 @@ test('keywords over multiple lines', async () => {
 
   const detailParm = invoice_get_invoice.subItems[2];
   expect(detailParm.name).toBe(`details`);
-  expect(detailParm.keyword[`LIKEDS`]).toBe(`INVOICE_GET_INVOICE_SALES_DETAIL_DS`);
-  expect(detailParm.keyword[`DIM`]).toBe(`INVOICE_MAX_DETAILS`);
+  expect(detailParm.keyword[`LIKEDS`]).toBe(`invoice_get_invoice_sales_detail_ds`);
+  expect(detailParm.keyword[`DIM`]).toBe(`invoice_max_details`);
 
   const count_details = invoice_get_invoice.subItems[3];
   expect(count_details.name).toBe(`count_details`);
@@ -1302,5 +1303,5 @@ test('keywords over multiple lines', async () => {
 
   const error = invoice_get_invoice.subItems[4];
   expect(error.name).toBe(`error`);
-  expect(error.keyword[`LIKE`]).toBe(`TERROR`);
+  expect(error.keyword[`LIKE`]).toBe(`TError`);
 })

--- a/tests/suite/directives.test.ts
+++ b/tests/suite/directives.test.ts
@@ -603,7 +603,6 @@ test('macro defined test 1', async () => {
 
   const cache = await parser.getDocs(uri, lines, { withIncludes: true, ignoreCache: true });
 
-  console.log(cache.procedures);
   expect(cache.includes.length).toBe(1);
   expect(cache.procedures.length).toBe(1);
 })
@@ -622,7 +621,6 @@ test('macro defined test 2', async () => {
 
   const cache = await parser.getDocs(uri, lines, { withIncludes: true, ignoreCache: true });
 
-  console.log(cache.procedures);
   expect(cache.includes.length).toBe(1);
   expect(cache.procedures.length).toBe(0);
 });
@@ -641,7 +639,6 @@ test('depth test', async () => {
 
   const cache = await parser.getDocs(uri, lines, { withIncludes: true, ignoreCache: true });
 
-  console.log(cache.procedures);
   expect(cache.includes.length).toBe(2);
   expect(cache.variables.length).toBe(3);
 })

--- a/tests/suite/files.test.ts
+++ b/tests/suite/files.test.ts
@@ -25,7 +25,7 @@ test("simple_file", async () => {
   const fileDef = cache.find(`employee`);
   expect(fileDef.name).toBe(`employee`);
   expect(fileDef.keyword[`DISK`]).toBe(true);
-  expect(fileDef.keyword[`USAGE`]).toBe(`*INPUT`);
+  expect(fileDef.keyword[`USAGE`]).toBe(`*input`);
 
   // file record formats should be expanded into the subitems
   expect(fileDef.subItems.length).toBe(1);
@@ -34,7 +34,7 @@ test("simple_file", async () => {
 
   expect(empRdcFmt.name).toBe(`EMPLOYEE`);
 
-  expect(empRdcFmt.subItems[1].keywords[0]).toBe(`VARCHAR(12)`);																	   
+  expect(empRdcFmt.subItems[1].keyword[`VARCHAR`]).toBe(`12`);																	   
   // 14 fields inside of this record format
   expect(empRdcFmt.subItems.length).toBe(14);
 });
@@ -186,5 +186,5 @@ test('file DS in a copy book', async () => {
   expect(someStruct).toBeDefined();
   expect(someStruct.subItems.length).toBeGreaterThan(0);
 
-  expect(someStruct.subItems.map(s => ({name: s.name, keywords: s.keywords}))).toMatchObject(globalStruct.subItems.map(s => ({name: s.name, keywords: s.keywords})));
+  expect(someStruct.subItems.map(s => ({name: s.name, keyword: s.keyword}))).toMatchObject(globalStruct.subItems.map(s => ({name: s.name, keyword: s.keyword})));
 })

--- a/tests/suite/fixed.test.ts
+++ b/tests/suite/fixed.test.ts
@@ -27,13 +27,13 @@ test('fixed1', async () => {
   const wkCorp = cache.variables[0];
   expect(wkCorp.name).to.equal('wkCorp');
   expect(wkCorp.position.line).to.equal(3);
-  expect(wkCorp.keywords[0]).to.equal('CHAR(10)');
-  expect(wkCorp.keywords[1]).to.equal(`INZ('100')`);
+  expect(wkCorp.keyword[`CHAR`]).to.equal('10');
+  expect(wkCorp.keyword[`INZ`]).to.equal(`'100'`);
 
   const wkInvoice = cache.variables[1];
   expect(wkInvoice.name).to.equal('wkInvoice');
   expect(wkInvoice.position.line).to.equal(4);
-  expect(wkInvoice.keywords[0]).to.equal('CHAR(15)');
+  expect(wkInvoice.keyword[`CHAR`]).to.equal('15');
 });
 
 test('fixed2', async () => {
@@ -63,11 +63,10 @@ test('fixed2', async () => {
 
   expect(cache.variables.length).to.equal(13);
 
-  const CHARFields = cache.variables.filter(v => v.keywords[0].startsWith(`CHAR`));
+  const CHARFields = cache.variables.filter(v => v.keyword[`CHAR`] !== undefined);
   expect(CHARFields.length).to.equal(12);
 
   const countVar = cache.variables.find(v => v.name === `Count`);
-  expect(countVar.keywords[0]).to.equal(`PACKED(4:0)`);
   expect(countVar.keyword[`PACKED`]).to.equal(`4:0`);
 });
 
@@ -94,8 +93,6 @@ test('fixed3', async () => {
   const Worktype = cache.variables[0];
   expect(Worktype.name).to.equal('Worktype');
   expect(Worktype.position.line).to.equal(0);
-  expect(Worktype.keywords[0]).to.equal('CHAR(10)');
-  expect(Worktype.keywords[1]).to.equal(`INZ('*OUTQ')`);
   expect(Worktype.keyword[`CHAR`]).to.equal('10');
   expect(Worktype.keyword[`INZ`]).to.equal(`'*OUTQ'`);
 
@@ -194,7 +191,6 @@ test('fixed5', async () => {
   const RtvObjD = cache.procedures[0];
   expect(RtvObjD.name).to.equal(`RtvObjD`);
   expect(RtvObjD.position.line).to.equal(18);
-  expect(RtvObjD.keywords.join(` `).trim()).to.equal(`EXTPGM( 'QUSROBJD' )`);
   expect(RtvObjD.keyword[`EXTPGM`]).to.equal(`'QUSROBJD'`);
   expect(RtvObjD.subItems.length).to.equal(6);
 });
@@ -220,23 +216,18 @@ test('fixed6', async () => {
   const lenVar = cache.find(`len`);
   expect(lenVar.name).to.equal(`len`);
   expect(lenVar.position.line).to.equal(6);
-  expect(lenVar.keywords[0]).to.equal(`INT(5)`);
   expect(lenVar.keyword[`INT`]).to.equal(`5`);
 
   const date2Var = cache.find(`DATE2`);
   expect(date2Var.name).to.equal(`DATE2`);
   expect(date2Var.position.line).to.equal(3);
-  expect(date2Var.keywords[0]).to.equal(`DATE`);
   expect(date2Var.keyword[`DATE`]).to.equal(true);
-  expect(date2Var.keywords[1]).to.equal(`DATFMT(*JIS)`);
   expect(date2Var.keyword[`DATFMT`]).to.equal(`*JIS`);
 
   const time0Var = cache.find(`TIME0`);
   expect(time0Var.name).to.equal(`TIME0`);
   expect(time0Var.position.line).to.equal(7);
-  expect(time0Var.keywords[0]).to.equal(`TIME`);
   expect(time0Var.keyword[`TIME`]).to.equal(true);
-  expect(time0Var.keywords[1]).to.equal(`INZ(T'10.12.15')`);
   expect(time0Var.keyword[`INZ`]).to.equal(`T'10.12.15'`);
 });
 
@@ -266,9 +257,7 @@ test('fixed7', async () => {
   const Obj_Next = cache.find(`Obj_Next`);
   expect(Obj_Next.name).to.equal(`Obj_Next`);
   expect(Obj_Next.position.line).to.equal(3);
-  expect(Obj_Next.keywords.includes(`EXPORT`)).to.equal(true);
   expect(Obj_Next.keyword[`EXPORT`]).to.equal(true);
-  expect(Obj_Next.keywords.includes(`LIKEDS(OBJECTDS)`)).to.equal(true);
   expect(Obj_Next.keyword[`LIKEDS`]).to.equal(`OBJECTDS`);
   expect(Obj_Next.subItems.length).to.equal(0);
 });
@@ -360,8 +349,6 @@ test('fixed9', async () => {
   const Obj_Next = cache.find(`Obj_Next`);
   expect(Obj_Next.name).to.equal(`Obj_Next`);
   expect(Obj_Next.position.line).to.equal(5);
-  expect(Obj_Next.keywords.includes(`EXPORT`)).to.equal(true);
-  expect(Obj_Next.keywords.includes(`LIKEDS(OBJECTDS)`)).to.equal(true);
   expect(Obj_Next.keyword[`EXPORT`]).to.equal(true);
   expect(Obj_Next.keyword[`LIKEDS`]).to.equal(`OBJECTDS`);
   expect(Obj_Next.subItems.length).to.equal(0);
@@ -369,7 +356,7 @@ test('fixed9', async () => {
   const theExtProcedure = cache.find(`theExtProcedure`);
   expect(theExtProcedure.name).to.equal(`theExtProcedure`);
   expect(theExtProcedure.position.line).to.equal(2);
-  expect(theExtProcedure.keywords.includes(`EXTPROC`)).to.equal(true);
+  expect(theExtProcedure.keyword[`EXTPROC`]).to.equal(true);
   expect(theExtProcedure.subItems.length).to.equal(1);
 });
 
@@ -402,8 +389,6 @@ test('fixed9_2', async () => {
   const Obj_Next = cache.find(`Obj_Next`);
   expect(Obj_Next.name).to.equal(`Obj_Next`);
   expect(Obj_Next.position.line).to.equal(5);
-  expect(Obj_Next.keywords.includes(`EXPORT`)).to.equal(true);
-  expect(Obj_Next.keywords.includes(`LIKEDS(OBJECTDS)`)).to.equal(true);
   expect(Obj_Next.keyword[`EXPORT`]).to.equal(true);
   expect(Obj_Next.keyword[`LIKEDS`]).to.equal(`OBJECTDS`);
   expect(Obj_Next.subItems.length).to.equal(0);
@@ -411,7 +396,7 @@ test('fixed9_2', async () => {
   const theExtProcedure = cache.find(`theExtProcedure`);
   expect(theExtProcedure.name).to.equal(`theExtProcedure`);
   expect(theExtProcedure.position.line).to.equal(2);
-  expect(theExtProcedure.keywords.includes(`EXTPROC`)).to.equal(true);
+  expect(theExtProcedure.keyword[`EXTPROC`]).to.equal(true);
   expect(theExtProcedure.subItems.length).to.equal(1);
 });
 
@@ -468,12 +453,10 @@ test('fixed10', async () => {
 
   const rrn02 = cache.find(`rrn02`);
   expect(rrn02.name).to.equal(`rrn02`);
-  expect(rrn02.keywords.includes(`PACKED(7:2)`)).to.equal(true);
   expect(rrn02.keyword[`PACKED`]).to.equal(`7:2`);
 
   const arsalePr = dataDs.subItems[3];
   expect(arsalePr.name).to.equal(`arsalePr`);
-  expect(arsalePr.keywords.includes(`ZONED(7:2)`)).to.equal(true);
   expect(arsalePr.keyword[`ZONED`]).to.equal(`7:2`);
 });
 
@@ -536,7 +519,7 @@ test('fixedfree1', async () => {
   const cache = await parser.getDocs(uri, lines, { ignoreCache: true, withIncludes: true });
 
   expect(cache.variables.length).to.equal(3);
-  expect(cache.variables.find(i => !i.keywords.includes(`CHAR(10)`))).to.be.undefined;
+  expect(cache.variables.find(i => !i.keyword[`CHAR`])).to.be.undefined;
 
   expect(cache.subroutines.length).to.equal(0);
 
@@ -547,12 +530,11 @@ test('fixedfree1', async () => {
   expect(Obj_List.range.start).to.equal(6);
   expect(Obj_List.range.end).to.equal(50);
   expect(Obj_List.position.line).to.equal(6);
-  expect(Obj_List.keywords.includes(`EXPORT`)).to.equal(true);
   expect(Obj_List.keyword[`EXPORT`]).to.equal(true);
   expect(Obj_List.subItems.length).to.equal(3);
 
-  expect(Obj_List.subItems.find(i => !i.keywords.includes(`CHAR(10)`))).to.be.undefined;
-  expect(Obj_List.subItems.find(i => !i.keywords.includes(`CONST`))).to.be.undefined;
+  expect(Obj_List.subItems.find(i => !i.keyword[`CHAR`])).to.be.undefined;
+  expect(Obj_List.subItems.find(i => !i.keyword[`CONST`])).to.be.undefined;
 
   const scope = Obj_List.scope;
   expect(scope.subroutines.length).to.equal(1);
@@ -582,18 +564,18 @@ test('fixed11', async () => {
   expect(F4DATE.range.end).to.equal(4);
 
   const parm1 = F4DATE.subItems[0];
-  expect(parm1.keywords[0]).to.equal(`CHAR(1)`);
+  expect(parm1.keyword[`CHAR`]).to.equal(`1`);
 
   const parm2 = F4DATE.subItems[1];
-  expect(parm2.keywords[0]).to.equal(`CHAR(15)`);
+  expect(parm2.keyword[`CHAR`]).to.equal(`15`);
 
   const parm3 = F4DATE.subItems[2];
-  expect(parm3.keywords[0]).to.equal(`CHAR(6)`);
-  expect(parm3.keywords[1]).to.equal(`OPTIONS(*NOPASS)`);
+  expect(parm3.keyword[`CHAR`]).to.equal(`6`);
+  expect(parm3.keyword[`OPTIONS`]).to.equal(`*NOPASS`);
 
   const parm4 = F4DATE.subItems[3];
-  expect(parm4.keywords[0]).to.equal(`CHAR(1)`);
-  expect(parm4.keywords[1]).to.equal(`OPTIONS(*NOPASS)`);
+  expect(parm4.keyword[`CHAR`]).to.equal(`1`);
+  expect(parm4.keyword[`OPTIONS`]).to.equal(`*NOPASS`);
 
   const F4DATEDS = cache.find(`F4DATEDS`);
   expect(F4DATEDS.subItems.length).to.equal(4);

--- a/tests/suite/linter.test.ts
+++ b/tests/suite/linter.test.ts
@@ -2792,6 +2792,8 @@ test("issue_175", async () => {
     NoUnreferenced: true
   }, cache);
 
+  console.log(errors);
+  console.log(lines.substring(errors[0].offset.position, errors[0].offset.end));
   expect(errors.length).toBe(0);
 });
 

--- a/tests/suite/linter.test.ts
+++ b/tests/suite/linter.test.ts
@@ -3,6 +3,7 @@ import path from "path";
 import setupParser from "../parserSetup";
 import Linter from "../../language/linter";
 import { test, expect } from "vitest";
+import { tokenise } from "../../language/tokens";
 
 const parser = setupParser();
 const uri = `source.rpgle`;
@@ -2792,8 +2793,6 @@ test("issue_175", async () => {
     NoUnreferenced: true
   }, cache);
 
-  console.log(errors);
-  console.log(lines.substring(errors[0].offset.position, errors[0].offset.end));
   expect(errors.length).toBe(0);
 });
 


### PR DESCRIPTION
Clean up keyword handling by consolidating keyword variants and updating the language server to utilize a new interface for keywords. Fix unreferenced tests to ensure proper functionality.