### PR TITLE
Refactor parser comment handling and improve token escape logic with tests

### DIFF
--- a/language/parser.ts
+++ b/language/parser.ts
@@ -395,34 +395,20 @@ export default class Parser {
         if (!inputLine.includes(`;`)) return inputLine;
         let comment = -1;
         let inString = false;
-        let sep = -1;
         for (let i = inputLine.length - 1; i >= 0; i--) {
           switch (inputLine[i]) {
-            case '/':
-              if (inputLine[i-1] === `/`) {
-                // It's a comment!
-                inString = false;
-                comment = i-1;
-                i--;
-              }
-              break;
             case `'`:
               inString = !inString;
               break;
             case ';':
               if (!inString) {
-                sep = i;
-                break;
+                return inputLine.substring(0, i + (withSep ? 1 : 0)).trimEnd();
               }
               break;
           }
         }
-        
-        if (comment >= 0 && comment < sep) {
-          return inputLine;
-        }
 
-        return (sep >= 0 ? inputLine.substring(0, sep + (withSep ? 1 : 0)) : inputLine);
+        return inputLine;
       }
 
       const expandDs = async (fileUri: string, fileToken: Token, ds: Declaration): Promise<void> => {

--- a/language/tokens.ts
+++ b/language/tokens.ts
@@ -329,7 +329,7 @@ export function tokenise(statement: string, options: TokeniseOptions = {}): Toke
       switch (statement[i]) {
       // When it's the string character..
       case stringChar:
-        const possibleEscape = statement[i+1] === stringChar;
+        const possibleEscape = statement[i+1] === stringChar && statement[i-1] !== stringChar;
         if (state === ReadState.IN_STRING) {
           if (possibleEscape) {
             currentText += `''`;

--- a/tests/suite/linter.test.ts
+++ b/tests/suite/linter.test.ts
@@ -3270,3 +3270,54 @@ test('issue_353_indent_3', async () => {
   expect(errors.length).toBe(0);
   expect(indentErrors.length).toBe(0);
 });
+
+test('issue_353_indent_4', async () => {
+  const lines = [
+    `**FREE`,
+    `dcl-c @QUOTE                   '''';`,
+    ``,
+    `dcl-c @SOMETHING_IN_BETWEEN 'whatever';`,
+    ``,
+    `dcl-c @SEUCOMMENT_FREE  '//&& ';`,
+    `// ********************************************************************`,
+    ``,
+    `dcl-ds copybookinfo_t           qualified template inz;`,
+    `  qualObj;`,
+    `  file                  Char(10)    overlay(qualObj: 1);`,
+    `  lib                   Char(10)    overlay(qualObj: *NEXT);`,
+    `  mbr                   Char(10);`,
+    `  found                 Ind         inz(*OFF);`,
+    `end-ds;`,
+    `// ********************************************************************`,
+  ].join(`\r\n`);
+
+  const cache = await parser.getDocs(uri, lines, { ignoreCache: true, withIncludes: false });
+
+  const atQuote = cache.find(`@QUOTE`);
+  expect(atQuote).toBeDefined();
+  expect(atQuote).toBeDefined();
+  expect(atQuote.keyword[`CONST`]).toBe(`''`);
+
+  const atSomethingInBetween = cache.find(`@SOMETHING_IN_BETWEEN`);
+  expect(atSomethingInBetween).toBeDefined();
+  expect(atSomethingInBetween.keyword[`CONST`]).toBe(`'whatever'`);
+
+  const atSeuCommentFree = cache.find(`@SEUCOMMENT_FREE`);
+  expect(atSeuCommentFree).toBeDefined();
+  expect(atSeuCommentFree.keyword[`CONST`]).toBe(`'//&& '`);
+
+  const copybookinfo_t = cache.find(`copybookinfo_t`);
+  expect(copybookinfo_t).toBeDefined();
+  expect(copybookinfo_t.subItems.length).toBe(5);
+  expect(copybookinfo_t.keyword[`QUALIFIED`]).toBe(true);
+  expect(copybookinfo_t.keyword[`TEMPLATE`]).toBe(true);
+  expect(copybookinfo_t.keyword[`INZ`]).toBe(true);
+
+  const { indentErrors, errors } = Linter.getErrors({ uri, content: lines }, {
+    indent: 2
+  }, cache);
+
+  expect(errors.length).toBe(0);
+  console.log(indentErrors);
+  expect(indentErrors.length).toBe(0);
+});


### PR DESCRIPTION
Enhance the parser's handling of comments and escape sequences while adding tests for various indentation scenarios.

Fixes #353.