### PR TITLE
Add navigation commands for fixed-format areas in RPGLE

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,20 @@
 				"category": "RPGLE",
 				"enablement": "code-for-ibmi:connected",
 				"icon": "$(refresh)"
+			},
+			{
+				"command": "vscode-rpgle.assist.moveLeft",
+				"title": "Move Left",
+				"category": "RPGLE Fixed-Format",
+				"icon": "$(arrow-left)",
+				"when": "editorLangId == rpgle"
+			},
+			{
+				"command": "vscode-rpgle.assist.moveRight",
+				"title": "Move Right",
+				"category": "RPGLE Fixed-Format",
+				"icon": "$(arrow-right)",
+				"when": "editorLangId == rpgle"
 			}
 		],
 		"keybindings": [
@@ -95,6 +109,18 @@
 				"command": "vscode-rpgle.assist.toggleFixedRuler",
 				"key": "shift+f4",
 				"mac": "shift+f4",
+				"when": "editorLangId == rpgle"
+			},
+			{
+				"command": "vscode-rpgle.assist.moveLeft",
+				"key": "ctrl+[",
+				"mac": "ctrl+[",
+				"when": "editorLangId == rpgle"
+			},
+			{
+				"command": "vscode-rpgle.assist.moveRight",
+				"key": "ctrl+]",
+				"mac": "ctrl+]",
 				"when": "editorLangId == rpgle"
 			}
 		],


### PR DESCRIPTION
Introduce commands to jump left and right between areas in fixed-format RPGLE code, enhancing navigation capabilities within the editor. Include checks for free format to ensure commands are only active in the appropriate context.