### PR TITLE
Fix/day_1

### DIFF
--- a/extension/client/src/extension.ts
+++ b/extension/client/src/extension.ts
@@ -22,6 +22,7 @@ import { clearTableCache, buildRequestHandlers } from './requests';
 import { getServerImplementationProvider, getServerSymbolProvider } from './language/serverReferences';
 import { checkAndWait, loadBase, onCodeForIBMiConfigurationChange } from './base';
 import { registerCommands } from './commands';
+import { setLanguageSettings } from './language/config';
 
 let client: LanguageClient;
 
@@ -101,7 +102,7 @@ export function activate(context: ExtensionContext) {
 	
 	context.subscriptions.push(getServerSymbolProvider());
 	context.subscriptions.push(getServerImplementationProvider());
-
+	context.subscriptions.push(setLanguageSettings());
 	// context.subscriptions.push(...initBuilder(client));
 
 

--- a/extension/client/src/language/config.ts
+++ b/extension/client/src/language/config.ts
@@ -1,0 +1,7 @@
+import { languages } from "vscode";
+
+export function setLanguageSettings() {
+  return languages.setLanguageConfiguration(`rpgle`, {
+    wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g
+  });
+}

--- a/extension/server/src/providers/index.ts
+++ b/extension/server/src/providers/index.ts
@@ -22,6 +22,8 @@ export function findFile(fileString: string, scheme = ``) {
 
 export const parser = new Parser();
 
+const wordMatch = /[\w\#\$@]/;
+
 export function getWordRangeAtPosition(document: TextDocument, position: Position): string|undefined {
 	const lines = document.getText().split(`\n`); // Safe to assume \n because \r is then at end of lines
 	const line = Math.min(lines.length - 1, Math.max(0, position.line));
@@ -29,12 +31,12 @@ export function getWordRangeAtPosition(document: TextDocument, position: Positio
 	const character = Math.min(lineText.length - 1, Math.max(0, position.character));
 
 	let startChar = character;
-	while (startChar > 0 && !/[\s\W]/.test(lineText.charAt(startChar - 1))) {
+	while (startChar > 0 && wordMatch.test(lineText.charAt(startChar - 1))) {
 		startChar -= 1;
 	}
 
 	let endChar = character;
-	while (endChar < lineText.length && (!/[\s\W]/.test(lineText.charAt(endChar + 1)))) {
+	while (endChar < lineText.length && wordMatch.test(lineText.charAt(endChar + 1))) {
 		endChar += 1;
 	}
 

--- a/language/linter.ts
+++ b/language/linter.ts
@@ -9,6 +9,7 @@ import Document from "./document";
 import { IssueRange, Rules, SelectBlock } from "./parserTypes";
 import Declaration from "./models/declaration";
 import { IRange, Token } from "./types";
+import { NO_NAME } from "./statement";
 
 const BANNED_FROM_INCLUDES = [`NoUnreferenced`];
 const INCLUDE_EXTENSIONS = [`rpgleinc`, `rpgleh`];
@@ -1097,7 +1098,7 @@ export default class Linter {
               // We only check the subfields if the parent is never references.
 
               struct.subItems.forEach(subf => {
-                if (subf.references.length <= 1) {
+                if (subf.name !== NO_NAME && subf.references.length <= 1) {
                   // Add an error to subf
                   const possibleStatement = doc.getStatementByLine(subf.position.range.line);
                   if (possibleStatement) {

--- a/language/linter.ts
+++ b/language/linter.ts
@@ -122,7 +122,7 @@ export default class Linter {
 
     for (let si = 0; si < doc.statements.length; si++) {
       const docStatement = doc.statements[si];
-      const statement = docStatement.tokens;
+      const statement = docStatement.tokens.some(t => t.type === `newline`) ? docStatement.tokens.filter(t => t.type !== `newline`) : docStatement.tokens;
       lineNumber = docStatement.range.line;
       currentIndent = docStatement.indent;
 

--- a/language/parser.ts
+++ b/language/parser.ts
@@ -9,6 +9,7 @@ import oneLineTriggers from "./models/oneLineTriggers";
 import { parseFLine, parseCLine, parsePLine, parseDLine, getPrettyType, prettyTypeFromToken } from "./models/fixed";
 import { Token } from "./types";
 import { Keywords } from "./parserTypes";
+import { NO_NAME } from "./statement";
 
 const HALF_HOUR = (30 * 60 * 1000);
 
@@ -1242,7 +1243,7 @@ export default class Parser {
                   }
 
                   currentSub = new Declaration(`subitem`);
-                  currentSub.name = (parts[0] === `*N` ? `parm${currentItem.subItems.length+1}` : partsLower[0]);
+                  currentSub.name = (parts[0] === NO_NAME ? NO_NAME : partsLower[0]);
                   currentSub.keyword = Parser.expandKeywords(tokens.slice(1));
 
                   currentSub.position = {
@@ -1540,7 +1541,7 @@ export default class Parser {
               switch (dSpec.field && dSpec.field.value) {
               case `C`:
                 currentItem = new Declaration(`constant`);
-                currentItem.name = potentialName ? potentialName.value : `*N`;
+                currentItem.name = potentialName ? potentialName.value : NO_NAME;
                 currentItem.keyword = dSpec.keywords || {};
                   
                 // TODO: line number might be different with ...?
@@ -1554,7 +1555,7 @@ export default class Parser {
                 break;
               case `S`:
                 currentItem = new Declaration(`variable`);
-                currentItem.name = potentialName ? potentialName.value : `*N`;
+                currentItem.name = potentialName ? potentialName.value : NO_NAME;
                 currentItem.keyword = {
                   ...dSpec.keywords,
                   ...prettyTypeFromToken(dSpec),
@@ -1572,7 +1573,7 @@ export default class Parser {
 
               case `DS`:
                 currentItem = new Declaration(`struct`);
-                currentItem.name = potentialName ? potentialName.value : `*N`;
+                currentItem.name = potentialName ? potentialName.value : NO_NAME;
                 currentItem.keyword = dSpec.keywords;
 
                 currentItem.position = {
@@ -1596,7 +1597,7 @@ export default class Parser {
                 // Only add a PR if it's not been defined
                 if (potentialName && !scope.procedures.find(proc => proc.name && proc.name.toUpperCase() === potentialName.value.toUpperCase())) {
                   currentItem = new Declaration(`procedure`);
-                  currentItem.name = potentialName ? potentialName.value : `*N`;
+                  currentItem.name = potentialName ? potentialName.value : NO_NAME;
                   currentItem.keyword = {
                     ...prettyTypeFromToken(dSpec),
                     ...dSpec.keywords
@@ -1662,7 +1663,7 @@ export default class Parser {
                   if (!potentialName && baseToken) {
                     potentialName = {
                       ...baseToken,
-                      value: `parm${currentItem.subItems.length+1}`
+                      value: NO_NAME
                     }
                   }
 

--- a/language/statement.ts
+++ b/language/statement.ts
@@ -1,6 +1,8 @@
 import { createBlocks } from "./tokens";
 import { IRange, IRangeWithLine, Token } from "./types";
 
+export const NO_NAME = `*N`;
+
 export default class Statement {
 	private beginBlock = false;
 

--- a/language/tokens.ts
+++ b/language/tokens.ts
@@ -59,7 +59,7 @@ const commonMatchers: Matcher[] = [
       { type: `asterisk` },
       {
         type: `word`, match: (word) =>
-          [`PSSR`, `CTDATA`, `BLANK`, `BLANKS`, `ZERO`, `ZEROS`, `ON`, `OFF`, `NULL`, `ISO`, `MDY`, `DMY`, `EUR`, `YMD`, `USA`, `SECONDS`, `S`, `MINUTES`, `MN`, `HOURS`, `H`, `DAYS`, `D`, `MONTHS`, `M`, `YEARS`, `Y`, `HIVAL`, `END`, `LOVAL`, `START`, `N`, `OMIT`, `STRING`, `CWIDEN`, `CONVERT`].includes(word.toUpperCase()) || word.toUpperCase().startsWith(`IN`)
+          [`PSSR`, `INZSR`, `CTDATA`, `BLANK`, `BLANKS`, `ZERO`, `ZEROS`, `ON`, `OFF`, `NULL`, `ISO`, `MDY`, `DMY`, `EUR`, `YMD`, `USA`, `SECONDS`, `S`, `MINUTES`, `MN`, `HOURS`, `H`, `DAYS`, `D`, `MONTHS`, `M`, `YEARS`, `Y`, `HIVAL`, `END`, `LOVAL`, `START`, `N`, `OMIT`, `STRING`, `CWIDEN`, `CONVERT`].includes(word.toUpperCase()) || word.toUpperCase().startsWith(`IN`)
       }
     ],
     becomes: {

--- a/tests/parserSetup.ts
+++ b/tests/parserSetup.ts
@@ -31,6 +31,8 @@ export default function setupParser(projectRoot = TEST_INCLUDE_DIR): Parser {
 	parser.setIncludeFileFetch(async (baseFile: string, includeFile: string) => {
 		if (includeFile.startsWith(`'`) && includeFile.endsWith(`'`)) {
 			includeFile = includeFile.substring(1, includeFile.length - 1);
+		} else if (includeFile.startsWith(`"`) && includeFile.endsWith(`"`)) {
+			includeFile = includeFile.substring(1, includeFile.length - 1);
 		}
 
 		if (includeFile.includes(`,`) || !includeFile.includes(`.`)) {

--- a/tests/rpgle/db00030s_h.rpgleinc
+++ b/tests/rpgle/db00030s_h.rpgleinc
@@ -1,0 +1,15 @@
+**free
+Dcl-Pr  DB00030_getDescriptionByCode Like(ds_Incoterms.Description) ExtProc('DB00030_getDescriptionByCode');
+   pIncotermCode  Like(ds_Incoterms.IncotermCode)  Const;
+End-Pr;
+
+Dcl-Pr  DB00030_checkIncotermCode Ind ExtProc('DB00030_checkIncotermCode');
+   pIncotermCode  Like(ds_Incoterms.IncotermCode)  Const;
+End-Pr;
+
+Dcl-Pr DB00030_getError VarChar(256) ExtProc('DB00030_getError');
+   pErrId Int(10) Options(*NoPass:*Omit);
+End-Pr;
+
+Dcl-DS ds_Incoterms Ext ExtName('VW_INCTRMS') Alias Qualified;  // view over functions table 
+End-DS;

--- a/tests/rpgle/db00040s_h.rpgleinc
+++ b/tests/rpgle/db00040s_h.rpgleinc
@@ -1,0 +1,21 @@
+**free
+Dcl-Pr  DB00040_getDescriptionByRecycCode Like(ds_recycling.description) ExtProc(*DclCase);
+   pRecycCode    Like(ds_recycling.RecycCode)  Const;
+End-Pr;
+Dcl-Pr  DB00040_getImageFileByRecycCode Like(ds_recycling.imageFile) ExtProc(*DclCase);
+   pRecycCode    Like(ds_recycling.RecycCode)  Const;
+End-Pr;
+Dcl-Pr  DB00040_checkRecordByRecycCode Ind ExtProc(*DclCase);
+   pRecycCode    Like(ds_recycling.RecycCode)  Const;
+End-Pr;
+
+Dcl-Pr  DB00040_getRecordByRecycCode LikeDs(ds_recycling) ExtProc(*DclCase);
+   pRecycCode    Like(ds_recycling.RecycCode)  Const;
+End-Pr;
+
+Dcl-Pr DB00040_getRecycError VarChar(256) ExtProc(*DclCase);
+   pErrId Int(10) Options(*NoPass:*Omit);
+End-Pr;
+
+Dcl-Ds ds_recycling Ext ExtName('VW_RECYC') Inz Alias Qualified;  // view 
+End-Ds;

--- a/tests/suite/basics.test.ts
+++ b/tests/suite/basics.test.ts
@@ -1357,3 +1357,21 @@ test('header file parse', async () => {
 
   expect(cache.procedures[0].name).toBe(`APIVAL01S_iws_validate`);
 });
+
+test('can define on the first line', async () => {
+  const lines = [
+    `        begsr sub1;`,
+    `        endsr;`,
+    `        `,
+    `        begsr sub2;`,
+    `        endsr;`,
+    ``,
+    `        `,
+    ``,
+    `        begsr sub3;`,
+    `        endsr;`,
+  ].join(`\n`);
+
+  const cache = await parser.getDocs(uri, lines, { ignoreCache: true, withIncludes: false });
+  expect(cache.subroutines.length).toBe(3);
+});

--- a/tests/suite/directives.test.ts
+++ b/tests/suite/directives.test.ts
@@ -641,4 +641,16 @@ test('depth test', async () => {
 
   expect(cache.includes.length).toBe(2);
   expect(cache.variables.length).toBe(3);
-})
+});
+
+test('fixed copy with comment and using double quotes', async () => {
+  const lines = [
+    `     h bnddir('M11')`,
+    `      /copy "./rpgle/db00030s_h.rpgleinc"    // Recycling codes`,
+    `      /copy "./rpgle/db00040s_h.rpgleinc" `,
+  ].join(`\n`);
+
+  const cache = await parser.getDocs(uri, lines, { withIncludes: true, ignoreCache: true });
+
+  expect(cache.includes.length).toBe(2);
+});

--- a/tests/suite/linter.test.ts
+++ b/tests/suite/linter.test.ts
@@ -3542,3 +3542,61 @@ test('issue_358_no_reference_2', async () => {
     }
   }
 });
+
+
+test('no names cannot be referenced', async () => {
+  const lines = [
+  `**FREE`,
+  `//...`,
+  `// Valid commands and the corresponding object type`,
+  `DCL-DS CommandsDS;`,
+  `  *n CHAR(10) INZ('CRTCMD');`,
+  `  *n CHAR(10) INZ('CRTBNDCL');`,
+  `  *n CHAR(10) INZ('CRTCLMOD');`,
+  `  *n CHAR(10) INZ('CRTDSPF');`,
+  `  *n CHAR(10) INZ('CRTPRTF');`,
+  `  *n CHAR(10) INZ('CRTLF');`,
+  `  *n CHAR(10) INZ('CRTPF');`,
+  `  *n CHAR(10) INZ('CRTMNU');`,
+  `  *n CHAR(10) INZ('CRTPNLGRP');`,
+  `  *n CHAR(10) INZ('CRTQMQRY');`,
+  `  *n CHAR(10) INZ('CRTSRVPGM');`,
+  `  *n CHAR(10) INZ('CRTWSCST');`,
+  `  *n CHAR(10) INZ('CRTRPGPGM');`,
+  `  *n CHAR(10) INZ('CRTSQLRPG');`,
+  `  Commands CHAR(10) DIM(14) POS(1);`,
+  `END-DS;`,
+  ``,
+  `DCL-DS ObjTypesDS;`,
+  `  *n CHAR(10) INZ('CMD');`,
+  `  *n CHAR(10) INZ('PGM');`,
+  `  *n CHAR(10) INZ('MODULE');`,
+  `  *n CHAR(10) INZ('FILE');`,
+  `  *n CHAR(10) INZ('FILE');`,
+  `  *n CHAR(10) INZ('FILE');`,
+  `  *n CHAR(10) INZ('FILE');`,
+  `  *n CHAR(10) INZ('MENU');`,
+  `  *n CHAR(10) INZ('PNLGRP');`,
+  `  *n CHAR(10) INZ('QMQRY');`,
+  `  *n CHAR(10) INZ('SRVPGM');`,
+  `  *n CHAR(10) INZ('WSCST');`,
+  `  *n CHAR(10) INZ('PGM');`,
+  `  *n CHAR(10) INZ('PGM');`,
+  `  ObjTypes CHAR(10) DIM(14) POS(1);`,
+  `END-DS;`,
+  ].join(`\n`);
+
+  const cache = await parser.getDocs(uri, lines, { ignoreCache: true, withIncludes: true, collectReferences: true });
+  const { errors } = Linter.getErrors({ uri, content: lines }, {
+    NoUnreferenced: true
+  }, cache);
+
+  expect(errors.length).toBe(4);
+
+  const unusedNames = [`Commands`, `CommandsDS`, `ObjTypes`, `ObjTypesDS`];
+  
+  for (let i = 0; i < errors.length; i++) {
+    expect(errors[i].type).toBe(`NoUnreferenced`);
+    expect(lines.substring(errors[i].offset.start, errors[i].offset.end).includes(unusedNames[i])).toBeTruthy();
+  }
+});

--- a/tests/suite/linter.test.ts
+++ b/tests/suite/linter.test.ts
@@ -3600,3 +3600,28 @@ test('no names cannot be referenced', async () => {
     expect(lines.substring(errors[i].offset.start, errors[i].offset.end).includes(unusedNames[i])).toBeTruthy();
   }
 });
+
+test('NoSELECTAll across multiple lines', () => {
+  const lines = [
+    `**free`,
+    `dcl-s i int(10);`,
+    `dcl-s j int(10);`,
+    `dcl-s k int(10);`,
+    ``,
+    `exec sql`,
+    `  select`,
+    `  *`,
+    `  into`,
+    `  :aDS`,
+    `  from`,
+    `  myfile`,
+    `  fetch first row only;`,
+  ].join(`\n`);
+
+  const { errors } = Linter.getErrors({ uri, content: lines }, {
+    NoSELECTAll: true
+  });
+
+  expect(errors.length).toBe(1);
+  expect(errors[0].type).toBe(`NoSELECTAll`);
+});


### PR DESCRIPTION
* Fix #185 and don't allow references on no named subfields
* Allow double quotes to be used in include/copy directive (#339)
* Fix bug with `NoSELECTAll`: Trim new lines from statement token list for linter
* Fix bug with `NoGlobalSubroutines`: allow use of special subroutines (#243)
* Allow use of special characters in language server. (#333)