### PR TITLE
Support *libl lookups in language server

### DIFF
--- a/extension/server/src/server.ts
+++ b/extension/server/src/server.ts
@@ -232,6 +232,10 @@ parser.setIncludeFileFetch(async (stringUri: string, includeString: string) => {
 			let baseFile = parts.file || `QRPGLESRC`;
 			let baseMember = parts.name;
 
+			if (parts.library && parts.library.startsWith(`*`)) {
+				parts.library = undefined;
+			}
+
 			if (parts.library) {
 				cleanString = [
 					``,

--- a/language/parser.ts
+++ b/language/parser.ts
@@ -117,7 +117,7 @@ export default class Parser {
 	 * @returns {string|undefined}
 	 */
   static getIncludeFromDirective(line: string): string|undefined {
-    if (line.includes(`*`)) return; // Likely comment
+    if (line.indexOf(`*`) !== line.toLowerCase().indexOf(`*libl`)) return; // Likely comment
     if (line.trim().startsWith(`//`)) return; // Likely comment
 
     const upperLine = line.toUpperCase();

--- a/tests/suite/directives.test.ts
+++ b/tests/suite/directives.test.ts
@@ -2,6 +2,7 @@ import path from "path";
 import setupParser from "../parserSetup";
 import Linter from "../../language/linter";
 import { test, expect } from "vitest";
+import Parser from "../../language/parser";
 
 const parser = setupParser();
 const uri = `source.rpgle`;
@@ -653,4 +654,12 @@ test('fixed copy with comment and using double quotes', async () => {
   const cache = await parser.getDocs(uri, lines, { withIncludes: true, ignoreCache: true });
 
   expect(cache.includes.length).toBe(2);
+});
+
+test('test copy with *libl', async () => {
+  const valueA = Parser.getIncludeFromDirective(`/copy qrpgleref,stufh`);
+  expect(valueA).toBe(`qrpgleref,stufh`);
+
+  const valueB = Parser.getIncludeFromDirective(`/copy *libl/qrpgleref,stufh`);
+  expect(valueB).toBe(`*libl/qrpgleref,stufh`);
 });


### PR DESCRIPTION
Implement support for library list lookups in the language server when the `*libl` special value is used, enhancing the parser to correctly handle directives involving *libl.