### PR TITLE
Code Actions cleanup

### DIFF
--- a/extension/server/src/providers/apis/codeActions.ts
+++ b/extension/server/src/providers/apis/codeActions.ts
@@ -1,0 +1,56 @@
+import { CodeAction, CodeActionKind, CodeActionParams, Position, Range, TextEdit } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { documents, parser, prettyKeywords } from '..';
+import Cache from '../../../../../language/models/cache';
+
+export default async function genericCodeActionsProvider(params: CodeActionParams): Promise<CodeAction[]|undefined> {
+	const uri = params.textDocument.uri;
+	const range = params.range;
+	const document = documents.get(uri);
+
+	if (document) {
+		const isFree = (document.getText(Range.create(0, 0, 0, 6)).toUpperCase() === `**FREE`);
+		if (isFree) {
+			const docs = await parser.getDocs(document.uri);
+
+			if (docs) {
+				const testCaseOption = getTestCaseAction(document, docs, range);
+				if (testCaseOption) {
+					return [testCaseOption];
+				}
+			}
+		}
+	}
+
+	return;
+}
+
+export function getTestCaseAction(document: TextDocument, docs: Cache, range: Range): CodeAction|undefined {
+	const currentProcedure = docs.procedures.find(sub => range.start.line >= sub.position.range.line && sub.range.start && sub.range.end);
+	if (currentProcedure) {
+
+		const refactorAction = CodeAction.create(`Create IBM i test case`, CodeActionKind.RefactorExtract);
+
+		const preCall = currentProcedure.subItems.map(s => `dcl-s ${s.name} ${prettyKeywords(s.keyword)};`);
+
+		refactorAction.edit = {
+			changes: {
+				['mynewtest.rpgle']: [
+					TextEdit.insert(
+						Position.create(0, 0), // Insert at the start of the new test case file
+						[
+							`**free`,
+							``,
+							`dcl-proc test_${currentProcedure.name.toLowerCase()} export;`,
+							``,
+							`end-proc;`
+						].join(`\n`)
+						
+					)
+				]
+			},
+		};
+
+		return refactorAction;
+	}
+}

--- a/extension/server/src/providers/codeActions.ts
+++ b/extension/server/src/providers/codeActions.ts
@@ -2,36 +2,52 @@ import { CodeAction, CodeActionKind, CodeActionParams, Position, Range, TextEdit
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { documents, parser, prettyKeywords } from '.';
 import Cache from '../../../../language/models/cache';
+import { getLinterCodeActions } from './linter/codeActions';
+import { createExtract, caseInsensitiveReplaceAll } from './language';
 
-export default async function genericCodeActionsProvider(params: CodeActionParams): Promise<CodeAction[]|undefined> {
+export default async function genericCodeActionsProvider(params: CodeActionParams): Promise<CodeAction[] | undefined> {
 	const uri = params.textDocument.uri;
 	const range = params.range;
 	const document = documents.get(uri);
 
-	if (document) {
-		const isFree = (document.getText(Range.create(0, 0, 0, 6)).toUpperCase() === `**FREE`);
-		if (isFree) {
-			const docs = await parser.getDocs(document.uri);
+	let actions: CodeAction[] = [];
 
-			if (docs) {
-				const testCaseOption = getTestCaseAction(document, docs, range);
-				if (testCaseOption) {
-					return [testCaseOption];
+	if (document) {
+		const docs = await parser.getDocs(document.uri);
+		if (docs) {
+			const isFree = (document.getText(Range.create(0, 0, 0, 6)).toUpperCase() === `**FREE`);
+			if (isFree) {
+				const subroutineOption = getSubroutineActions(document, docs, range);
+				if (subroutineOption) {
+					return [subroutineOption];
 				}
+
+				const extractOption = getExtractProcedureAction(document, docs, range);
+				if (extractOption) {
+					return [extractOption];
+				}
+
+				const linterActions = await getLinterCodeActions(docs, document, range);
+				if (linterActions) {
+					actions = actions.concat(linterActions);
+				}
+			}
+
+			const testCaseOption = getTestCaseAction(document, docs, range);
+			if (testCaseOption) {
+				actions.push(testCaseOption);
 			}
 		}
 	}
 
-	return;
+	return actions;
 }
 
-export function getTestCaseAction(document: TextDocument, docs: Cache, range: Range): CodeAction|undefined {
+export function getTestCaseAction(document: TextDocument, docs: Cache, range: Range): CodeAction | undefined {
 	const currentProcedure = docs.procedures.find(sub => range.start.line >= sub.position.range.line && sub.range.start && sub.range.end);
 	if (currentProcedure) {
 
 		const refactorAction = CodeAction.create(`Create IBM i test case`, CodeActionKind.RefactorExtract);
-
-		const preCall = currentProcedure.subItems.map(s => `dcl-s ${s.name} ${prettyKeywords(s.keyword)};`);
 
 		refactorAction.edit = {
 			changes: {
@@ -45,12 +61,110 @@ export function getTestCaseAction(document: TextDocument, docs: Cache, range: Ra
 							``,
 							`end-proc;`
 						].join(`\n`)
-						
+
 					)
 				]
 			},
 		};
 
 		return refactorAction;
+	}
+}
+
+export function getSubroutineActions(document: TextDocument, docs: Cache, range: Range): CodeAction|undefined {
+	if (range.start.line === range.end.line) {
+		const currentGlobalSubroutine = docs.subroutines.find(sub => sub.position.range.line === range.start.line && sub.range.start && sub.range.end);
+
+		if (currentGlobalSubroutine) {
+			const subroutineRange = Range.create(
+				Position.create(currentGlobalSubroutine.range.start!, 0),
+				Position.create(currentGlobalSubroutine.range.end!, 1000)
+			);
+
+			const bodyRange = Range.create(
+				Position.create(currentGlobalSubroutine.range.start! + 1, 0),
+				Position.create(currentGlobalSubroutine.range.end! - 1, 0)
+			);
+
+			// First, let's create the extract data
+			const extracted = createExtract(document, bodyRange, docs);
+
+			// Create the new procedure body
+			const newProcedure = [
+				`Dcl-Proc ${currentGlobalSubroutine.name};`,
+				`  Dcl-Pi *N;`,
+					  ...extracted.references.map((ref, i) => `    ${extracted.newParamNames[i]} ${ref.dec.type === `struct` ? `LikeDS` : `Like`}(${ref.dec.name});`),
+				`  End-Pi;`,
+				``,
+				caseInsensitiveReplaceAll(extracted.newBody, `leavesr`, `return`),
+				`End-Proc;`
+			].join(`\n`)
+
+			// Then update the references that invokes this subroutine
+			const referenceUpdates: TextEdit[] = currentGlobalSubroutine.references.map(ref => {
+				const lineNumber = document.positionAt(ref.offset.start).line;
+				// If this reference is outside of the subroutine
+				if (lineNumber < currentGlobalSubroutine.range.start! || lineNumber > currentGlobalSubroutine.range.end!) {
+					return TextEdit.replace(
+						Range.create(
+							// - 5 `EXSR `
+							document.positionAt(ref.offset.start - 5),
+							document.positionAt(ref.offset.end)
+						),
+						currentGlobalSubroutine.name + `(${extracted.references.map(r => r.dec.name).join(`:`)})`
+					);
+				}
+			}).map(x => x) as TextEdit[];
+
+			const refactorAction = CodeAction.create(`Convert to procedure`, CodeActionKind.RefactorExtract);
+			refactorAction.edit = {
+				changes: {
+					[document.uri]: [
+						...referenceUpdates,
+						TextEdit.replace(subroutineRange, newProcedure)
+					]
+				},
+			};
+
+			return refactorAction;
+		}
+	}
+}
+
+export function getExtractProcedureAction(document: TextDocument, docs: Cache, range: Range): CodeAction|undefined {
+	if (range.end.line > range.start.line) {
+			const lastLine = document.offsetAt({line: document.lineCount, character: 0});
+
+			const extracted = createExtract(document, range, docs);
+
+			const newProcedure = [
+				`Dcl-Proc NewProcedure;`,
+				`  Dcl-Pi *N;`,
+					  ...extracted.references.map((ref, i) => `    ${extracted.newParamNames[i]} ${ref.dec.type === `struct` ? `LikeDS` : `Like`}(${ref.dec.name});`),
+				`  End-Pi;`,
+				``,
+				extracted.newBody,
+				`End-Proc;`
+			].join(`\n`)
+
+			const newAction = CodeAction.create(`Extract to new procedure`, CodeActionKind.RefactorExtract);
+
+			// First do the exit
+			newAction.edit = {
+				changes: {
+					[document.uri]: [
+						TextEdit.replace(extracted.range, `NewProcedure(${extracted.references.map(r => r.dec.name).join(`:`)});`),
+						TextEdit.insert(document.positionAt(lastLine), `\n\n`+newProcedure)
+					]
+				},
+			};
+
+			// Then format the document
+			newAction.command = {
+				command: `editor.action.formatDocument`,
+				title: `Format`
+			};
+
+			return newAction;
 	}
 }

--- a/extension/server/src/providers/codeActions.ts
+++ b/extension/server/src/providers/codeActions.ts
@@ -33,10 +33,10 @@ export default async function genericCodeActionsProvider(params: CodeActionParam
 				}
 			}
 
-			const testCaseOption = getTestCaseAction(document, docs, range);
-			if (testCaseOption) {
-				actions.push(testCaseOption);
-			}
+			// const testCaseOption = getTestCaseAction(document, docs, range);
+			// if (testCaseOption) {
+			// 	actions.push(testCaseOption);
+			// }
 		}
 	}
 

--- a/extension/server/src/providers/codeActions.ts
+++ b/extension/server/src/providers/codeActions.ts
@@ -1,7 +1,7 @@
 import { CodeAction, CodeActionKind, CodeActionParams, Position, Range, TextEdit } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { documents, parser, prettyKeywords } from '..';
-import Cache from '../../../../../language/models/cache';
+import { documents, parser, prettyKeywords } from '.';
+import Cache from '../../../../language/models/cache';
 
 export default async function genericCodeActionsProvider(params: CodeActionParams): Promise<CodeAction[]|undefined> {
 	const uri = params.textDocument.uri;

--- a/extension/server/src/providers/language.ts
+++ b/extension/server/src/providers/language.ts
@@ -1,0 +1,58 @@
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Range } from "vscode-languageserver";
+import Cache from "../../../../language/models/cache";
+
+export function caseInsensitiveReplaceAll(text: string, search: string, replace: string) {
+	return text.replace(new RegExp(search, `gi`), replace);
+}
+
+export function createExtract(document: TextDocument, userRange: Range, docs: Cache) {
+	const range = Range.create(userRange.start.line, 0, userRange.end.line, 1000);
+	const references = docs.referencesInRange(document.uri, {start: document.offsetAt(range.start), end: document.offsetAt(range.end)});
+	const validRefs = references.filter(ref => [`struct`, `subitem`, `variable`].includes(ref.dec.type));
+
+	const nameDiffSize = 1; // Always once since we only add 'p' at the start
+	const newParamNames = validRefs.map(ref => `p${ref.dec.name}`);
+	let newBody = document.getText(range);
+
+	const rangeStartOffset = document.offsetAt(range.start);
+
+	// Fix the found offset lengths to be relative to the new procedure
+	for (let i = validRefs.length - 1; i >= 0; i--) {
+		for (let y = validRefs[i].refs.length - 1; y >= 0; y--) {
+			validRefs[i].refs[y] = {
+				start: validRefs[i].refs[y].start - rangeStartOffset,
+				end: validRefs[i].refs[y].end - rangeStartOffset
+			};
+		}
+	}
+
+	// Then let's fix the references to use the new names
+	for (let i = validRefs.length - 1; i >= 0; i--) {
+		for (let y = validRefs[i].refs.length - 1; y >= 0; y--) {
+			const ref = validRefs[i].refs[y];
+
+			newBody = newBody.slice(0, ref.start) + newParamNames[i] + newBody.slice(ref.end);
+			ref.end += nameDiffSize;
+
+			// Then we need to update the offset of the next references
+			for (let z = i - 1; z >= 0; z--) {
+				for (let x = validRefs[z].refs.length - 1; x >= 0; x--) {
+					if (validRefs[z].refs[x].start > ref.end) {
+						validRefs[z].refs[x] = {
+							start: validRefs[z].refs[x].start + nameDiffSize,
+							end: validRefs[z].refs[x].end + nameDiffSize
+						};
+					}
+				}
+			}
+		}
+	}
+
+	return {
+		newBody,
+		newParamNames,
+		references: validRefs,
+		range
+	}
+}

--- a/extension/server/src/providers/linter/codeActions.ts
+++ b/extension/server/src/providers/linter/codeActions.ts
@@ -1,42 +1,22 @@
 import { CodeAction, CodeActionKind, CodeActionParams, Range } from 'vscode-languageserver';
 import { getActions, getExtractProcedureAction, getSubroutineActions, refreshLinterDiagnostics } from '.';
 import { documents, parser } from '..';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import Cache from '../../../../../language/models/cache';
 
-export default async function codeActionsProvider(params: CodeActionParams): Promise<CodeAction[]|undefined> {
-	const uri = params.textDocument.uri;
-	const range = params.range;
-	const document = documents.get(uri);
+/**
+ * Get the CodeActions for a given document and range.
+ */
+export async function getLinterCodeActions(docs: Cache, document: TextDocument, range: Range) {
+	const detail = await refreshLinterDiagnostics(document, docs, false);
+	if (detail) {
+		const fixErrors = detail.errors.filter(error => 
+			range.start.line >= document.positionAt(error.offset.start!).line &&
+			range.end.line <= document.positionAt(error.offset.end!).line
+		);
 
-	if (document) {
-		const isFree = (document.getText(Range.create(0, 0, 0, 6)).toUpperCase() === `**FREE`);
-		if (isFree) {
-			const docs = await parser.getDocs(document.uri);
-
-			if (docs) {
-				const subroutineOption = getSubroutineActions(document, docs, range);
-				if (subroutineOption) {
-					return [subroutineOption];
-				}
-
-				const extractOption = getExtractProcedureAction(document, docs, range);
-				if (extractOption) {
-					return [extractOption];
-				}
-
-				const detail = await refreshLinterDiagnostics(document, docs, false);
-				if (detail) {
-					const fixErrors = detail.errors.filter(error => 
-						range.start.line >= document.positionAt(error.offset.start!).line &&
-						range.end.line <= document.positionAt(error.offset.end!).line
-					);
-
-					if (fixErrors.length > 0) {
-						return getActions(document, fixErrors);
-					}
-				}
-			}
+		if (fixErrors.length > 0) {
+			return getActions(document, fixErrors);
 		}
 	}
-
-	return;
 }

--- a/extension/server/src/providers/linter/index.ts
+++ b/extension/server/src/providers/linter/index.ts
@@ -6,7 +6,6 @@ import { documents, parser } from '..';
 import { IssueRange, Rules } from '../../../../../language/parserTypes';
 import Linter from '../../../../../language/linter';
 import Cache from '../../../../../language/models/cache';
-import codeActionsProvider from './codeActions';
 import documentFormattingProvider from './documentFormatting';
 
 import * as Project from "../project";
@@ -15,8 +14,11 @@ import { parseMemberUri } from '../../data';
 
 export let jsonCache: { [uri: string]: string } = {};
 
+export function isLinterEnabled() {
+	return true;
+}
+
 export function initialise(connection: _Connection) {
-	connection.onCodeAction(codeActionsProvider);
 	connection.onDocumentFormatting(documentFormattingProvider);
 
 	// This only works for local workspace files
@@ -431,158 +433,4 @@ export function getActions(document: TextDocument, errors: IssueRange[]) {
 	});
 
 	return actions;
-}
-
-export function getSubroutineActions(document: TextDocument, docs: Cache, range: Range): CodeAction|undefined {
-	if (range.start.line === range.end.line) {
-		const currentGlobalSubroutine = docs.subroutines.find(sub => sub.position.range.line === range.start.line && sub.range.start && sub.range.end);
-
-		if (currentGlobalSubroutine) {
-			const subroutineRange = Range.create(
-				Position.create(currentGlobalSubroutine.range.start!, 0),
-				Position.create(currentGlobalSubroutine.range.end!, 1000)
-			);
-
-			const bodyRange = Range.create(
-				Position.create(currentGlobalSubroutine.range.start! + 1, 0),
-				Position.create(currentGlobalSubroutine.range.end! - 1, 0)
-			);
-
-			// First, let's create the extract data
-			const extracted = createExtract(document, bodyRange, docs);
-
-			// Create the new procedure body
-			const newProcedure = [
-				`Dcl-Proc ${currentGlobalSubroutine.name};`,
-				`  Dcl-Pi *N;`,
-					  ...extracted.references.map((ref, i) => `    ${extracted.newParamNames[i]} ${ref.dec.type === `struct` ? `LikeDS` : `Like`}(${ref.dec.name});`),
-				`  End-Pi;`,
-				``,
-				caseInsensitiveReplaceAll(extracted.newBody, `leavesr`, `return`),
-				`End-Proc;`
-			].join(`\n`)
-
-			// Then update the references that invokes this subroutine
-			const referenceUpdates: TextEdit[] = currentGlobalSubroutine.references.map(ref => {
-				const lineNumber = document.positionAt(ref.offset.start).line;
-				// If this reference is outside of the subroutine
-				if (lineNumber < currentGlobalSubroutine.range.start! || lineNumber > currentGlobalSubroutine.range.end!) {
-					return TextEdit.replace(
-						Range.create(
-							// - 5 `EXSR `
-							document.positionAt(ref.offset.start - 5),
-							document.positionAt(ref.offset.end)
-						),
-						currentGlobalSubroutine.name + `(${extracted.references.map(r => r.dec.name).join(`:`)})`
-					);
-				}
-			}).map(x => x) as TextEdit[];
-
-			const refactorAction = CodeAction.create(`Convert to procedure`, CodeActionKind.RefactorExtract);
-			refactorAction.edit = {
-				changes: {
-					[document.uri]: [
-						...referenceUpdates,
-						TextEdit.replace(subroutineRange, newProcedure)
-					]
-				},
-			};
-
-			return refactorAction;
-		}
-	}
-}
-
-export function getExtractProcedureAction(document: TextDocument, docs: Cache, range: Range): CodeAction|undefined {
-	if (range.end.line > range.start.line) {
-			const lastLine = document.offsetAt({line: document.lineCount, character: 0});
-
-			const extracted = createExtract(document, range, docs);
-
-			const newProcedure = [
-				`Dcl-Proc NewProcedure;`,
-				`  Dcl-Pi *N;`,
-					  ...extracted.references.map((ref, i) => `    ${extracted.newParamNames[i]} ${ref.dec.type === `struct` ? `LikeDS` : `Like`}(${ref.dec.name});`),
-				`  End-Pi;`,
-				``,
-				extracted.newBody,
-				`End-Proc;`
-			].join(`\n`)
-
-			const newAction = CodeAction.create(`Extract to new procedure`, CodeActionKind.RefactorExtract);
-
-			// First do the exit
-			newAction.edit = {
-				changes: {
-					[document.uri]: [
-						TextEdit.replace(extracted.range, `NewProcedure(${extracted.references.map(r => r.dec.name).join(`:`)});`),
-						TextEdit.insert(document.positionAt(lastLine), `\n\n`+newProcedure)
-					]
-				},
-			};
-
-			// Then format the document
-			newAction.command = {
-				command: `editor.action.formatDocument`,
-				title: `Format`
-			};
-
-			return newAction;
-	}
-}
-
-function caseInsensitiveReplaceAll(text: string, search: string, replace: string) {
-	return text.replace(new RegExp(search, `gi`), replace);
-}
-	
-
-function createExtract(document: TextDocument, userRange: Range, docs: Cache) {
-	const range = Range.create(userRange.start.line, 0, userRange.end.line, 1000);
-	const references = docs.referencesInRange(document.uri, {start: document.offsetAt(range.start), end: document.offsetAt(range.end)});
-	const validRefs = references.filter(ref => [`struct`, `subitem`, `variable`].includes(ref.dec.type));
-
-	const nameDiffSize = 1; // Always once since we only add 'p' at the start
-	const newParamNames = validRefs.map(ref => `p${ref.dec.name}`);
-	let newBody = document.getText(range);
-
-	const rangeStartOffset = document.offsetAt(range.start);
-
-	// Fix the found offset lengths to be relative to the new procedure
-	for (let i = validRefs.length - 1; i >= 0; i--) {
-		for (let y = validRefs[i].refs.length - 1; y >= 0; y--) {
-			validRefs[i].refs[y] = {
-				start: validRefs[i].refs[y].start - rangeStartOffset,
-				end: validRefs[i].refs[y].end - rangeStartOffset
-			};
-		}
-	}
-
-	// Then let's fix the references to use the new names
-	for (let i = validRefs.length - 1; i >= 0; i--) {
-		for (let y = validRefs[i].refs.length - 1; y >= 0; y--) {
-			const ref = validRefs[i].refs[y];
-
-			newBody = newBody.slice(0, ref.start) + newParamNames[i] + newBody.slice(ref.end);
-			ref.end += nameDiffSize;
-
-			// Then we need to update the offset of the next references
-			for (let z = i - 1; z >= 0; z--) {
-				for (let x = validRefs[z].refs.length - 1; x >= 0; x--) {
-					if (validRefs[z].refs[x].start > ref.end) {
-						validRefs[z].refs[x] = {
-							start: validRefs[z].refs[x].start + nameDiffSize,
-							end: validRefs[z].refs[x].end + nameDiffSize
-						};
-					}
-				}
-			}
-		}
-	}
-
-	return {
-		newBody,
-		newParamNames,
-		references: validRefs,
-		range
-	}
 }

--- a/extension/server/src/server.ts
+++ b/extension/server/src/server.ts
@@ -30,7 +30,7 @@ import { dspffdToRecordFormats, isInMerlin, parseMemberUri } from './data';
 import path = require('path');
 import { existsSync } from 'fs';
 import { renamePrepareProvider, renameRequestProvider } from './providers/rename';
-import genericCodeActionsProvider from './providers/apis/codeActions';
+import genericCodeActionsProvider from './providers/codeActions';
 
 let hasConfigurationCapability = false;
 let hasWorkspaceFolderCapability = false;

--- a/extension/server/src/server.ts
+++ b/extension/server/src/server.ts
@@ -31,6 +31,7 @@ import path = require('path');
 import { existsSync } from 'fs';
 import { renamePrepareProvider, renameRequestProvider } from './providers/rename';
 import genericCodeActionsProvider from './providers/codeActions';
+import { isLinterEnabled } from './providers/linter';
 
 let hasConfigurationCapability = false;
 let hasWorkspaceFolderCapability = false;
@@ -39,7 +40,6 @@ let hasDiagnosticRelatedInformationCapability = false;
 const outsideMerlin = !isInMerlin();
 
 const languageToolsEnabled = outsideMerlin;
-const linterEnabled = true;
 const formatterEnabled = outsideMerlin;
 
 let projectEnabled = false;
@@ -79,7 +79,7 @@ connection.onInitialize((params: InitializeParams) => {
 		result.capabilities.renameProvider = {prepareProvider: true};
 	}
 
-	if (linterEnabled) {
+	if (isLinterEnabled()) {
 		result.capabilities.codeActionProvider = true;
 		if (formatterEnabled) {
 			result.capabilities.documentFormattingProvider = {
@@ -310,8 +310,7 @@ if (languageToolsEnabled) {
 	connection.onImplementation(implementationProvider);
 }
 
-// TODO: enable both code action providers
-// if (linterEnabled) Linter.initialise(connection);
+if (isLinterEnabled()) Linter.initialise(connection);
 
 // Always get latest stuff
 documents.onDidChangeContent(handler => {

--- a/extension/server/src/server.ts
+++ b/extension/server/src/server.ts
@@ -30,6 +30,7 @@ import { dspffdToRecordFormats, isInMerlin, parseMemberUri } from './data';
 import path = require('path');
 import { existsSync } from 'fs';
 import { renamePrepareProvider, renameRequestProvider } from './providers/rename';
+import genericCodeActionsProvider from './providers/apis/codeActions';
 
 let hasConfigurationCapability = false;
 let hasWorkspaceFolderCapability = false;
@@ -302,13 +303,15 @@ if (languageToolsEnabled) {
 	connection.onReferences(referenceProvider);
 	connection.onPrepareRename(renamePrepareProvider);
 	connection.onRenameRequest(renameRequestProvider);
+	connection.onCodeAction(genericCodeActionsProvider);
 
 	// project specific
 	connection.onWorkspaceSymbol(workspaceSymbolProvider);
-	connection.onImplementation(implementationProvider)
+	connection.onImplementation(implementationProvider);
 }
 
-if (linterEnabled) Linter.initialise(connection);
+// TODO: enable both code action providers
+// if (linterEnabled) Linter.initialise(connection);
 
 // Always get latest stuff
 documents.onDidChangeContent(handler => {


### PR DESCRIPTION
Previously, all code actions were tied to the linter. If there was no lint config, none of the code actions worked.

This PR achieves the following:

* Allow code actions to run no matter if linter is enabled or disabled
* Allow code actions to run without a lint config
* Allows code actions to run for non free-format code