### PR TITLE
Monitor code action

### DIFF
--- a/extension/server/src/data.ts
+++ b/extension/server/src/data.ts
@@ -58,7 +58,8 @@ export function dspffdToRecordFormats(data: any, aliases = false): Declaration[]
 			field: ``,
 			pos: ``
 		});
-		currentSubfield.description = text.trim();
+		
+		currentSubfield.tags.push({tag: `description`, content: text.trim()});
 
 		recordFormat.subItems.push(currentSubfield);
 	});

--- a/extension/server/src/providers/codeActions.ts
+++ b/extension/server/src/providers/codeActions.ts
@@ -92,7 +92,7 @@ function getBodyRangeForRange(docs: Cache, rangeStart: number, rangeEnd: number,
 	} else {
 		validStart = docs.getDefinitionBlockEnd(document.uri) + 1;
 		const firstProc = docs.procedures.find(p => !Object.keys(p.keyword).some(k => k.toLowerCase().startsWith(`ext`)));
-		validEnd = firstProc && firstProc.range.start ? firstProc.range.start - 1 : document.lineCount;
+		validEnd = firstProc && firstProc.range.start ? firstProc.range.start - 1 : document.lineCount - 1;
 	}
 
 	if (validStart < 0 || validEnd < 0) {

--- a/extension/server/src/providers/codeActions.ts
+++ b/extension/server/src/providers/codeActions.ts
@@ -114,6 +114,11 @@ export function surroundWithMonitorAction(isFree: boolean, document: TextDocumen
 	let rangeStart = range.start.line;
 	let rangeEnd = range.end.line;
 
+	if (rangeStart === rangeEnd) {
+		// Only works for multi-line selections
+		return;
+	}
+
 	const validRange = getBodyRangeForRange(docs, rangeStart, rangeEnd, document);
 
 	if (!validRange) {
@@ -227,8 +232,8 @@ export function getSubroutineActions(document: TextDocument, docs: Cache, range:
 }
 
 export function getExtractProcedureAction(document: TextDocument, docs: Cache, range: Range): CodeAction | undefined {
-	let rangeStart = range.start.line;
-	let rangeEnd = range.end.line;
+	const rangeStart = range.start.line;
+	const rangeEnd = range.end.line;
 	if (rangeEnd > rangeStart) {
 
 		const validRange = getBodyRangeForRange(docs, rangeStart, rangeEnd, document);

--- a/extension/server/src/providers/linter/codeActions.ts
+++ b/extension/server/src/providers/linter/codeActions.ts
@@ -1,6 +1,5 @@
-import { CodeAction, CodeActionKind, CodeActionParams, Range } from 'vscode-languageserver';
-import { getActions, getExtractProcedureAction, getSubroutineActions, refreshLinterDiagnostics } from '.';
-import { documents, parser } from '..';
+import { Range } from 'vscode-languageserver';
+import { getActions, refreshLinterDiagnostics } from '.';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import Cache from '../../../../../language/models/cache';
 

--- a/language/models/cache.ts
+++ b/language/models/cache.ts
@@ -86,7 +86,7 @@ export default class Cache {
    * @param {string} fsPath Path to check
    * @returns {number} Line number
    */
-  getDefinitionBlockEnd(fsPath) {
+  getDefinitionBlockEnd(fsPath: string) {
     const lasts = [
       this.procedures.filter(d => d.position.path === fsPath && d.keyword[`EXTPROC`] !== undefined).pop(),
       this.structs.filter(d => d.position.path === fsPath).pop(),

--- a/language/models/declaration.ts
+++ b/language/models/declaration.ts
@@ -39,4 +39,8 @@ export default class Declaration {
     //clone.scope = this.scope;
     return clone;
   }
+
+  get description() {
+    return this.tags.find(tag => tag.tag === `description`)?.content || ``;
+  }
 }


### PR DESCRIPTION
Adds a brand new code action to surround selected code into a `monitor` block.

Additionally:

* Extract to procedure uses new logic to ensure that the selected range can be extracted (`getBodyRangeForRange`)
* ~Adds a getter in `Declaration` for backwards compatability for `description`~ (fix on main now)