### PR TITLE
Add command to retrieve cache of parsed URIs

### DIFF
--- a/extension/client/src/commands.ts
+++ b/extension/client/src/commands.ts
@@ -1,11 +1,15 @@
-import { commands, ExtensionContext, window } from "vscode";
-import { clearTableCache } from "./requests";
+import { commands, ExtensionContext, Uri, window } from "vscode";
+import { clearTableCache, getCache } from "./requests";
 import { LanguageClient } from "vscode-languageclient/node";
 
 export function registerCommands(context: ExtensionContext, client: LanguageClient) {
   context.subscriptions.push(
     commands.registerCommand(`vscode-rpgle.server.reloadCache`, () => {
       clearTableCache(client);
+    }),
+
+    commands.registerCommand(`vscode-rpgle.server.getCache`, (uri: Uri) => {
+      return getCache(client, uri);
     })
   )
 }

--- a/extension/client/src/requests.ts
+++ b/extension/client/src/requests.ts
@@ -1,5 +1,5 @@
 import path = require('path');
-import { Uri, workspace, RelativePattern, commands } from 'vscode';
+import { Uri, workspace } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { getInstance } from './base';
 import { IBMiMember } from '@halcyontech/vscode-ibmi-types';
@@ -181,4 +181,8 @@ export function buildRequestHandlers(client: LanguageClient) {
 
 export function clearTableCache(client: LanguageClient) {
 	client.sendRequest(`clearTableCache`);
+}
+
+export function getCache(client: LanguageClient, uri: Uri): Promise<any> {
+	return client.sendRequest(`getCache`, uri.toString());
 }


### PR DESCRIPTION
Introduce a new extension command that allows users to get the cache of parsed URIs, enhancing the functionality of the extension.