### PR TITLE
Add bounds check and test for crash report #388

### DIFF
--- a/language/linter.ts
+++ b/language/linter.ts
@@ -757,7 +757,7 @@ export default class Linter {
                   case `DOU`:
                     if (rules.ForceOptionalParens) {
                       const lastStatement = statement[statement.length - 1];
-                      if (statement[1].type !== `openbracket` || lastStatement.type !== `closebracket`) {
+                      if (lastStatement && statement[1] &&(statement[1].type !== `openbracket` || lastStatement.type !== `closebracket`)) {
                         errors.push({
                           type: `ForceOptionalParens`,
                           offset: { start: statement[1].range.start, end: statement[statement.length - 1].range.end }


### PR DESCRIPTION
Implement a bounds check for the `ForceOptionalParens` property to prevent potential crashes. Add a test case to verify the behavior and ensure stability.

Fixes #388