### PR TITLE
Add fromPath to IncludeStatement and update Parser logic

### DIFF
--- a/language/parser.ts
+++ b/language/parser.ts
@@ -631,6 +631,7 @@ export default class Parser {
                     if (include.found && include.uri) {
                       if (!scopes[0].includes.some(inc => inc.toPath === include.uri)) {
                         scopes[0].includes.push({
+                          fromPath: fileUri,
                           toPath: include.uri,
                           line: lineNumber
                         });

--- a/language/parserTypes.ts
+++ b/language/parserTypes.ts
@@ -7,7 +7,7 @@ export interface Keywords {
 }
 
 export interface IncludeStatement {
-  /** vscode.Uri.path */
+  fromPath: string;
   toPath: string;
   line: number;
 }

--- a/tests/rpgle/depth1.rpgleinc
+++ b/tests/rpgle/depth1.rpgleinc
@@ -1,5 +1,7 @@
 **FREE
 
+// Hello world
+
 /include 'copy3.rpgle'
 
 Dcl-S Scooby varchar(40) template;

--- a/tests/suite/directives.test.ts
+++ b/tests/suite/directives.test.ts
@@ -249,6 +249,8 @@ test('eof4', async () => {
 
   expect(cache.includes.length).toBe(1);
   expect(cache.includes[0].line).toBe(4);
+  expect(cache.includes[0].fromPath).toBe(uri);
+  expect(cache.includes[0].toPath.endsWith(path.join(`rpgle`, `eof4.rpgle`))).toBeTruthy();
 
   expect(cache.variables.length).toBe(1);
   expect(cache.procedures.length).toBe(1);
@@ -641,6 +643,17 @@ test('depth test', async () => {
   const cache = await parser.getDocs(uri, lines, { withIncludes: true, ignoreCache: true });
 
   expect(cache.includes.length).toBe(2);
+
+  console.log(cache.includes);
+
+  expect(cache.includes[0].fromPath).toBe(uri);
+  expect(cache.includes[0].toPath.endsWith(path.join(`rpgle`, `depth1.rpgleinc`))).toBeTruthy();
+  expect(cache.includes[0].line).toBe(2); // zero indexed
+
+  expect(cache.includes[1].fromPath).toBe(cache.includes[0].toPath);
+  expect(cache.includes[1].toPath.endsWith(path.join(`rpgle`, `copy3.rpgle`))).toBeTruthy();
+  expect(cache.includes[1].line).toBe(4); // zero indexed
+
   expect(cache.variables.length).toBe(3);
 });
 


### PR DESCRIPTION
Introduce a new `fromPath` property to the `IncludeStatement` interface and modify the `Parser` class to utilize this property. 

Enhance directive tests to include checks for the new `fromPath` functionality and update depth test assertions accordingly.

Fixes #392