### PR TITLE
Differentiate between procedures and prototypes in language server

### DIFF
--- a/extension/server/src/providers/completionItem.ts
+++ b/extension/server/src/providers/completionItem.ts
@@ -10,7 +10,7 @@ import { getInterfaces } from './project/exportInterfaces';
 import Parser from '../../../../language/parser';
 
 const completionKind = {
-	function: CompletionItemKind.Function,
+	function: CompletionItemKind.Interface,
 	struct: CompletionItemKind.Struct
 };
 
@@ -127,7 +127,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 				} else {
 					const expandScope = (localCache: Cache) => {
 						for (const subItem of localCache.parameters) {
-							const item = CompletionItem.create(`${subItem.name}`);
+							const item = CompletionItem.create(subItem.name);
 							item.kind = CompletionItemKind.TypeParameter;
 							item.insertText = subItem.name;
 							item.detail = [`parameter`, prettyKeywords(subItem.keyword)].join(` `);
@@ -136,8 +136,8 @@ export default async function completionItemProvider(handler: CompletionParams):
 						}
 
 						for (const procedure of localCache.procedures) {
-							const item = CompletionItem.create(`${procedure.name}`);
-							item.kind = CompletionItemKind.Function;
+							const item = CompletionItem.create(procedure.name);
+							item.kind = procedure.prototype ? CompletionItemKind.Interface : CompletionItemKind.Function;
 							item.insertTextFormat = InsertTextFormat.Snippet;
 							item.insertText = `${procedure.name}(${procedure.subItems.map((parm, index) => `\${${index + 1}:${parm.name}}`).join(`:`)})`;
 							item.detail = prettyKeywords(procedure.keyword);
@@ -146,41 +146,41 @@ export default async function completionItemProvider(handler: CompletionParams):
 						}
 
 						for (const subroutine of localCache.subroutines) {
-							const item = CompletionItem.create(`${subroutine.name}`);
+							const item = CompletionItem.create(subroutine.name);
 							item.kind = CompletionItemKind.Function;
-							item.insertText = `${subroutine.name}`;
+							item.insertText = subroutine.name;
 							item.documentation = subroutine.description;
 							items.push(item);
 						}
 
 						for (const variable of localCache.variables) {
-							const item = CompletionItem.create(`${variable.name}`);
+							const item = CompletionItem.create(variable.name);
 							item.kind = CompletionItemKind.Variable;
-							item.insertText = `${variable.name}`;
+							item.insertText = variable.name;
 							item.detail = prettyKeywords(variable.keyword);
 							item.documentation = variable.description;
 							items.push(item);
 						}
 
 						localCache.files.forEach(file => {
-							const item = CompletionItem.create(`${file.name}`);
+							const item = CompletionItem.create(file.name);
 							item.kind = CompletionItemKind.File;
-							item.insertText = `${file.name}`;
+							item.insertText = file.name;
 							item.detail = prettyKeywords(file.keyword);
 							item.documentation = file.description;
 							items.push(item);
 
 							for (const struct of file.subItems) {
-								const item = CompletionItem.create(`${struct.name}`);
+								const item = CompletionItem.create(struct.name);
 								item.kind = CompletionItemKind.Struct;
-								item.insertText = `${struct.name}`;
+								item.insertText = struct.name;
 								item.detail = prettyKeywords(struct.keyword);
 								item.documentation = struct.description;
 								items.push(item);
 
 								if (!struct.keyword[`QUALIFIED`]) {
 									struct.subItems.forEach((subItem: Declaration) => {
-										const item = CompletionItem.create(`${subItem.name}`);
+										const item = CompletionItem.create(subItem.name);
 										item.kind = CompletionItemKind.Property;
 										item.insertText = `${subItem.name}`;
 										item.detail = prettyKeywords(subItem.keyword);
@@ -192,16 +192,16 @@ export default async function completionItemProvider(handler: CompletionParams):
 						});
 
 						for (const struct of localCache.structs) {
-							const item = CompletionItem.create(`${struct.name}`);
+							const item = CompletionItem.create(struct.name);
 							item.kind = CompletionItemKind.Struct;
-							item.insertText = `${struct.name}`;
+							item.insertText = struct.name;
 							item.detail = prettyKeywords(struct.keyword);
 							item.documentation = struct.description;
 							items.push(item);
 
 							if (!struct.keyword[`QUALIFIED`]) {
 								struct.subItems.forEach((subItem: Declaration) => {
-									const item = CompletionItem.create(`${subItem.name}`);
+									const item = CompletionItem.create(subItem.name);
 									item.kind = CompletionItemKind.Property;
 									item.insertText = `${subItem.name}`;
 									item.detail = prettyKeywords(subItem.keyword);
@@ -212,16 +212,16 @@ export default async function completionItemProvider(handler: CompletionParams):
 						}
 
 						for (const constant of localCache.constants) {
-							const item = CompletionItem.create(`${constant.name}`);
+							const item = CompletionItem.create(constant.name);
 							item.kind = CompletionItemKind.Constant;
-							item.insertText = `${constant.name}`;
+							item.insertText = constant.name;
 							item.detail = prettyKeywords(constant.keyword);
 							item.documentation = constant.description;
 							items.push(item);
 
 							if (!constant.keyword[`QUALIFIED`]) {
 								constant.subItems.forEach((subItem: Declaration) => {
-									const item = CompletionItem.create(`${subItem.name}`);
+									const item = CompletionItem.create(subItem.name);
 									item.kind = CompletionItemKind.Property;
 									item.insertText = `${subItem.name}`;
 									item.detail = prettyKeywords(subItem.keyword);
@@ -244,7 +244,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 						// So if the user is in the middle of a statement, then they still exist in the subItems
 						else if (currentProcedure.subItems.length > 0) {
 							for (const subItem of currentProcedure.subItems) {
-								const item = CompletionItem.create(`${subItem.name}`);
+								const item = CompletionItem.create(subItem.name);
 								item.kind = CompletionItemKind.TypeParameter;
 								item.insertText = subItem.name;
 								item.detail = [`parameter`, prettyKeywords(subItem.keyword)].join(` `);

--- a/extension/server/src/providers/documentSymbols.ts
+++ b/extension/server/src/providers/documentSymbols.ts
@@ -50,7 +50,7 @@ export default async function documentSymbolProvider(handler: DocumentSymbolPara
 					const procDef = DocumentSymbol.create(
 						proc.name,
 						prettyKeywords(proc.keyword),
-						SymbolKind.Function,
+						proc.prototype ? SymbolKind.Interface : SymbolKind.Function,
 						Range.create(proc.range.start!, 0, proc.range.end!, 0),
 						Range.create(proc.range.start!, 0, proc.range.start!, 0),
 					);

--- a/language/models/cache.ts
+++ b/language/models/cache.ts
@@ -117,7 +117,8 @@ export default class Cache {
     const searchIn = [
       this.parameters,
       this.constants,
-      this.procedures,
+      this.procedures.filter(p => !p.prototype), //Regular procedures
+      this.procedures.filter(p => p.prototype), //Prototypes
       this.files,
       allStructs,
       this.subroutines,
@@ -132,7 +133,7 @@ export default class Cache {
     }
 
     if (includeProcedure) {
-      const procedureScope = this.procedures.find(proc => proc.name.toUpperCase() === includeProcedure);
+      const procedureScope = this.procedures.find(proc => proc.name.toUpperCase() === includeProcedure && proc.scope !== undefined);
       if (procedureScope) {
         const found = procedureScope.scope.find(name);
         if (found) return found;

--- a/language/models/declaration.ts
+++ b/language/models/declaration.ts
@@ -8,13 +8,20 @@ type DeclarationType = "procedure"|"subroutine"|"file"|"struct"|"subitem"|"varia
 export default class Declaration {
   name: string = ``;
   keyword: Keywords = {};
+  prototype: boolean = false;
   tags: {tag: string, content: string}[] = [];
+  /**
+   * Position is the location of the declaration in the source file, by offset and line number.
+   */
   position: {path: string, range: IRangeWithLine};
   references: Reference[] = [];
   subItems: Declaration[] = [];
   readParms: boolean = false;
+  /**
+   * This range property is solely line numbers.
+   */
   range: {start: number|null, end: number|null} = {start: null, end: null};
-  scope: Cache|undefined;
+  scope?: Cache;
   constructor(public type: DeclarationType) {}
 
   clone() {

--- a/language/parser.ts
+++ b/language/parser.ts
@@ -1449,7 +1449,7 @@ export default class Parser {
               if (cSpec.factor2) {
                 const f2Value = cSpec.factor2.value;
                 callItem.name = (f2Value.startsWith(`'`) && f2Value.endsWith(`'`) ? f2Value.substring(1, f2Value.length-1) : f2Value);
-                callItem.keyword = {'EXTPGM': true}
+                callItem.keyword = {'CALL': true}
                 callItem.tags = currentTags;
 
                 callItem.position = {

--- a/language/parser.ts
+++ b/language/parser.ts
@@ -932,34 +932,33 @@ export default class Parser {
           case `DCL-PR`:
             if (currentItem === undefined) {
               if (parts.length > 1) {
-                if (!scope.procedures.find(proc => proc.name && proc.name.toUpperCase() === parts[1])) {
-                  currentGroup = `procedures`;
-                  currentItem = new Declaration(`procedure`);
-                  currentItem.name = partsLower[1];
-                  currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
-                  currentItem.tags = currentTags;
+                currentGroup = `procedures`;
+                currentItem = new Declaration(`procedure`);
+                currentItem.name = partsLower[1];
+                currentItem.prototype = true;
+                currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
+                currentItem.tags = currentTags;
 
-                  currentItem.position = {
-                    path: fileUri,
-                    range: tokens[1].range
-                  };
+                currentItem.position = {
+                  path: fileUri,
+                  range: tokens[1].range
+                };
 
-                  currentItem.readParms = true;
+                currentItem.readParms = true;
 
-                  currentItem.range = {
-                    start: currentStmtStart.line,
-                    end: currentStmtStart.line
-                  };
+                currentItem.range = {
+                  start: currentStmtStart.line,
+                  end: currentStmtStart.line
+                };
 
-                  // Does the keywords include a keyword that makes end-ds useless?
-                  if (Object.keys(currentItem.keyword).some(keyword => oneLineTriggers[`DCL-PR`].some(trigger => keyword.startsWith(trigger)))) {
-                    currentItem.range.end = currentStmtStart.line;
-                    scope.procedures.push(currentItem);
-                    resetDefinition = true;
-                  }
-
-                  currentDescription = [];
+                // Does the keywords include a keyword that makes end-ds useless?
+                if (Object.keys(currentItem.keyword).some(keyword => oneLineTriggers[`DCL-PR`].some(trigger => keyword.startsWith(trigger)))) {
+                  currentItem.range.end = currentStmtStart.line;
+                  scope.procedures.push(currentItem);
+                  resetDefinition = true;
                 }
+
+                currentDescription = [];
               }
             }
             break;
@@ -981,18 +980,7 @@ export default class Parser {
         
           case `DCL-PROC`:
             if (parts.length > 1) {
-            //We can overwrite it.. it might have been a PR before.
-            // eslint-disable-next-line no-case-declarations
               currentItem = new Declaration(`procedure`);
-
-              const existingProcI = scope.procedures.findIndex(proc => proc.name && proc.name.toUpperCase() === parts[1]);
-              const existingProc = scope.procedures[existingProcI];
-
-              // We found the PR... so we can overwrite it
-              if (existingProc) {
-                currentItem.references.push(...existingProc.references);
-                scope.procedures.splice(existingProcI, 1);
-              }
 
               currentProcName = partsLower[1];
               currentItem.name = currentProcName;
@@ -1025,7 +1013,7 @@ export default class Parser {
             if (parts.length > 0) {
               if (currentProcName) {
                 currentGroup = `procedures`;
-                currentItem = scopes[0].procedures.find(proc => proc.name === currentProcName);
+                currentItem = scopes[0].procedures.find(proc => !proc.prototype && proc.name === currentProcName);
               } else {
                 currentItem = new Declaration(`struct`);
                 currentItem.name = PROGRAMPARMS_NAME;
@@ -1513,16 +1501,6 @@ export default class Parser {
                 if (potentialName) {
                   currentItem = new Declaration(`procedure`);
 
-                  //We can overwrite it.. it might have been a PR before.
-                  const existingProcI = potentialName ? scope.procedures.findIndex(proc => proc.name && proc.name.toUpperCase() === potentialName.value.toUpperCase()) : -1;
-                  const existingProc = scope.procedures[existingProcI];
-
-                  // We found the PR... so we can overwrite it
-                  if (existingProc) {
-                    currentItem.references.push(...existingProc.references);
-                    scope.procedures.splice(existingProcI, 1);
-                  }
-
                   currentProcName = potentialName.value;
                   currentItem.name = currentProcName;
                   currentItem.keyword = pSpec.keywords;
@@ -1629,35 +1607,33 @@ export default class Parser {
                 break;
 
               case `PR`:
-                // Only add a PR if it's not been defined
-                if (potentialName && !scope.procedures.find(proc => proc.name && proc.name.toUpperCase() === potentialName.value.toUpperCase())) {
-                  currentItem = new Declaration(`procedure`);
-                  currentItem.name = potentialName ? potentialName.value : NO_NAME;
-                  currentItem.keyword = {
-                    ...prettyTypeFromToken(dSpec),
-                    ...dSpec.keywords
-                  }
-  
-                  currentItem.position = {
-                    path: fileUri,
-                    range: useNameToken.range
-                  };
-  
-                  currentItem.range = {
-                    start: currentItem.position.range.line,
-                    end: currentItem.position.range.line
-                  };
-  
-                  currentGroup = `procedures`;
-                  scope.procedures.push(currentItem);
-                  currentDescription = [];
+                currentItem = new Declaration(`procedure`);
+                currentItem.name = potentialName ? potentialName.value : NO_NAME;
+                currentItem.prototype = true;
+                currentItem.keyword = {
+                  ...prettyTypeFromToken(dSpec),
+                  ...dSpec.keywords
                 }
+
+                currentItem.position = {
+                  path: fileUri,
+                  range: useNameToken.range
+                };
+
+                currentItem.range = {
+                  start: currentItem.position.range.line,
+                  end: currentItem.position.range.line
+                };
+
+                currentGroup = `procedures`;
+                scope.procedures.push(currentItem);
+                currentDescription = [];
                 break;
 
               case `PI`:
                 //Procedures can only exist in the global scope.
                 if (currentProcName) {
-                  currentItem = scopes[0].procedures.find(proc => proc.name === currentProcName);
+                  currentItem = scopes[0].procedures.find(proc => proc && !proc.prototype && proc.name === currentProcName);
 
                   currentGroup = `procedures`;
                   if (currentItem) {

--- a/tests/suite/basics.test.ts
+++ b/tests/suite/basics.test.ts
@@ -150,6 +150,11 @@ test('vitestTest6', async () => {
 
   expect(cache.variables.length).toBe(1);
   expect(cache.procedures.length).toBe(1);
+
+  const resolved = cache.find(`TheProcedure`);
+  expect(resolved).toBeDefined();
+  expect(resolved.name).toBe(`TheProcedure`);
+  expect(resolved.prototype).toBeTruthy();
 });
 
 /**
@@ -177,8 +182,20 @@ test('vitestTest7', async () => {
   const cache = await parser.getDocs(uri, lines, {withIncludes: true, ignoreCache: true});
 
   expect(cache.variables.length).toBe(1);
-  expect(cache.procedures.length).toBe(1);
+  expect(cache.procedures.length).toBe(2);
+
+  expect(cache.procedures[0].name).toBe(`TheProcedure`);
+  expect(cache.procedures[0].prototype).toBeTruthy();
   expect(cache.procedures[0].subItems.length).toBe(1);
+
+  expect(cache.procedures[1].name).toBe(`theProcedure`);
+  expect(cache.procedures[1].prototype).toBeFalsy();
+  expect(cache.procedures[1].subItems.length).toBe(1);
+
+  const resolved = cache.find(`TheProcedure`);
+  expect(resolved).toBeDefined();
+  expect(resolved.name).toBe(`theProcedure`);
+  expect(resolved.prototype).toBeFalsy();
 });
 
 /**
@@ -203,8 +220,20 @@ test('vitestTest7_fixed', async () => {
 
   const cache = await parser.getDocs(uri, lines, {withIncludes: true, ignoreCache: true});
 
-  expect(cache.procedures.length).toBe(1);
+  expect(cache.procedures.length).toBe(2);
+  
+  expect(cache.procedures[0].name).toBe(`GetArtDesc`);
   expect(cache.procedures[0].subItems.length).toBe(1);
+  expect(cache.procedures[0].prototype).toBeTruthy();
+
+  expect(cache.procedures[1].name).toBe(`GetArtDesc`);
+  expect(cache.procedures[1].subItems.length).toBe(1);
+  expect(cache.procedures[1].prototype).toBeFalsy();
+
+  const resolved = cache.find(`GetArtDesc`);
+  expect(resolved).toBeDefined();
+  expect(resolved.name).toBe(`GetArtDesc`);
+  expect(resolved.prototype).toBeFalsy();
 });
 
 /**
@@ -1595,9 +1624,20 @@ test('fixed-format c spec', async () => {
 
   const cache = await parser.getDocs(uri, lines, { ignoreCache: true, withIncludes: false });
   expect(cache.constants.length).toBe(0);
-  expect(cache.procedures.length).toBe(1);
+  expect(cache.procedures.length).toBe(2);
+  
   expect(cache.procedures[0].name).toBe(`UpdArt`);
+  expect(cache.procedures[0].prototype).toBeTruthy();
   expect(cache.procedures[0].subItems.length).toBe(2);
+
+  expect(cache.procedures[1].name).toBe(`UpdArt`);
+  expect(cache.procedures[1].prototype).toBeFalsy();
+  expect(cache.procedures[1].subItems.length).toBe(2);
+
+  const resolved = cache.find(`UpdArt`);
+  expect(resolved).toBeDefined();
+  expect(resolved.name).toBe(`UpdArt`);
+  expect(resolved.prototype).toBeFalsy();
 
   expect(cache.structs.length).toBe(3);
   expect(cache.variables.length).toBe(1);

--- a/tests/suite/fixed.test.ts
+++ b/tests/suite/fixed.test.ts
@@ -1064,7 +1064,7 @@ test('call_opcode', async () => {
 
   const fixedCall = cache.find(`BBSWINASKR`)
   expect(fixedCall.name).to.equal(`BBSWINASKR`);
-  expect(fixedCall.keyword[`EXTPGM`]).to.equal(true);
+  expect(fixedCall.keyword[`CALL`]).to.equal(true);
 });
 
 test('file_keywords', async () => {


### PR DESCRIPTION
Update the language server to distinguish between procedures and prototypes, ensuring procedures do not overwrite prototype definitions. Improve test cases to validate this functionality.

![image](https://github.com/user-attachments/assets/dea83035-5eac-40f2-992f-7e98714e38c4)

Additionally, updates the `CALL` fixed-format symbol to use a `call` keyword instead of `extpgm`.

<img width="962" alt="image" src="https://github.com/user-attachments/assets/f24f6d8b-0e99-4162-ac9a-2c4563db22ae" />

Fixes #391.