### PR TITLE
Add missing indicators to default cache

### DIFF
--- a/language/models/cache.ts
+++ b/language/models/cache.ts
@@ -2,8 +2,19 @@ import { CacheProps, IncludeStatement, Keywords } from "../parserTypes";
 import { IRange } from "../types";
 import Declaration from "./declaration";
 
+const DEFAULT_INDICATORS = [
+  ...Array(98).keys(), 
+  `LR`, `KL`, `MR`,
+  `L1`, `L2`, `L3`, `L4`, `L5`, `L6`, `L7`, `L8`, `L9`,
+  `U1`, `U2`, `U3`, `U4`, `U5`, `U6`, `U7`, `U8`,
+  `OA`, `OB`, `OC`, `OD`, `OE`, `OF`, `OG`, `OV`,
+  `KA`, `KB`, `KC`, `KD`, `KE`, `KF`, `KG`, `KH`, `KI`, `KJ`, `KK`, `KL`, `KM`, `KN`,
+  `KP`, `KQ`, `KR`, `KS`, `KT`, `KU`, `KV`, `KW`, `KX`, `KY`,
+  `H1`, `H2`, `H3`, `H4`, `H5`, `H6`, `H7`, `H8`, `H9`
+];
+
 const newInds = () => {
-  return [...Array(98).keys(), `LR`, `KL`].map(val => `IN${val.toString().padStart(2, `0`)}`).map(ind => {
+  return DEFAULT_INDICATORS.map(val => `IN${val.toString().padStart(2, `0`)}`).map(ind => {
     const indDef = new Declaration(`variable`);
     indDef.name = ind;
     indDef.keyword = { IND: true };

--- a/language/models/fixed.js
+++ b/language/models/fixed.js
@@ -64,6 +64,7 @@ export function parseFLine(lineNumber, lineIndex, content) {
  */
 export function parseCLine(lineNumber, lineIndex, content) {
   content = content.padEnd(80);
+  const clIndicator = content.substr(7, 8).toUpperCase();
   const indicator = content.substr(9, 11);
   const factor1 = content.substr(11, 14);
   const opcode = content.substr(25, 10).toUpperCase();
@@ -79,6 +80,7 @@ export function parseCLine(lineNumber, lineIndex, content) {
   const ind3 = content.substr(74, 2);
 
   return {
+    clIndicator: calculateToken(lineNumber, lineIndex+7, clIndicator, `special-ind`),
     indicator: calculateToken(lineNumber, lineIndex+9, indicator, `special-ind`),
     opcode: calculateToken(lineNumber, lineIndex+25, opcode, `opcode`),
     factor1: calculateToken(lineNumber, lineIndex+11, factor1),

--- a/language/parser.ts
+++ b/language/parser.ts
@@ -1382,7 +1382,7 @@ export default class Parser {
           case `C`:
             const cSpec = parseCLine(lineNumber, lineIndex, line);
 
-            tokens = [cSpec.indicator, cSpec.ind1, cSpec.ind2, cSpec.ind3];
+            tokens = [cSpec.clIndicator, cSpec.indicator, cSpec.ind1, cSpec.ind2, cSpec.ind3];
 
             const fromToken = (token?: Token) => {
               return token ? Parser.lineTokens(token.value, lineNumber, token.range.start) : [];


### PR DESCRIPTION
Include additional indicators in the default cache and update parsing of C spec to add missing control indicator.