### PR TITLE
Fix prototype reference issue in parser

### DIFF
--- a/language/parser.ts
+++ b/language/parser.ts
@@ -332,7 +332,7 @@ export default class Parser {
 
       const scanScopeForReferences = () => {
         for (const procedure in postProcessingStatements) {
-          const currentProcedure = scopes[0].procedures.find(proc => proc.name === procedure) ;
+          const currentProcedure = scopes[0].findDefinition(lineNumber, procedure);
           const statements = postProcessingStatements[procedure];
           for (const statement of statements) {
             collectReferences(fileUri, statement, currentProcedure);
@@ -1728,7 +1728,7 @@ export default class Parser {
         }
 
         if (options.collectReferences && tokens.length > 0) {
-          const currentProc = scopes[0].procedures.find(proc => proc.name === currentProcName);
+          const currentProc = currentProcName ? scopes[0].findDefinition(lineNumber, currentProcName) : undefined;
           collectReferences(fileUri, tokens, currentProc, currentItem);
           addPostProcessingStatements(currentProcName, tokens);
         }

--- a/tests/rpgle/empdet.rpgleinc
+++ b/tests/rpgle/empdet.rpgleinc
@@ -1,0 +1,22 @@
+**free
+
+dcl-ds employee_detail_t qualified template;
+  found ind;
+  name varchar(50);
+  netincome packed(9:2);
+end-ds;
+
+dcl-ds department_detail_t qualified template;
+  found ind;
+  deptname varchar(50);
+  location varchar(50);
+  totalsalaries packed(9:2);
+end-ds;
+
+dcl-pr getDeptDetail like(department_detail_t) extproc('GETDEPTDETAIL');
+  deptno char(3) const;
+end-pr;
+
+dcl-pr getEmployeeDetail like(employee_detail_t) extproc('GETEMPLOYEEDETAIL');
+  empno char(6) const;
+end-pr;


### PR DESCRIPTION
Correct the method for retrieving procedure definitions to ensure accurate prototype references in the parser. Add tests to validate the functionality.