### PR TITLE
Hide test functions from completion provider in local development

### DIFF
--- a/extension/server/src/providers/completionItem.ts
+++ b/extension/server/src/providers/completionItem.ts
@@ -136,6 +136,10 @@ export default async function completionItemProvider(handler: CompletionParams):
 						}
 
 						for (const procedure of localCache.procedures) {
+							if (procedure.prototype && localCache.procedures.some(proc => proc.name.toUpperCase() === procedure.name.toUpperCase() && !proc.prototype)) {
+								continue; // Skip if the actual procedure is already defined
+							}
+
 							const item = CompletionItem.create(procedure.name);
 							item.kind = procedure.prototype ? CompletionItemKind.Interface : CompletionItemKind.Function;
 							item.insertTextFormat = InsertTextFormat.Snippet;

--- a/extension/server/src/providers/project/exportInterfaces.ts
+++ b/extension/server/src/providers/project/exportInterfaces.ts
@@ -3,6 +3,8 @@ import { APIInterface } from '../apis';
 import { isEnabled } from '.';
 import { parser, prettyKeywords } from '..';
 
+const TEST_FUNCTIONS = [`SETUPSUITE`, `TEARDOWNSUITE`, `SETUP`, `TEARDOWN`];
+
 export function getInterfaces(): APIInterface[] {
 	let interfaces: APIInterface[] = [];
 
@@ -57,6 +59,14 @@ export function getInterfaces(): APIInterface[] {
 						// This might mean it is a module. Look for EXPORTs
 						cache.procedures.forEach(proc => {
 							if (proc.keyword[`EXPORT`]) {
+
+								if (TEST_FUNCTIONS.includes(proc.name.toUpperCase())) {
+									return; // Skip test functions
+								}
+
+								if (proc.name.toUpperCase().startsWith(`TEST`)) {
+									return; // Skip user test functions
+								}
 
 								proc.keyword[`EXTPROC`] = `'${proc.name.toUpperCase()}'`;
 

--- a/extension/server/src/providers/project/exportInterfaces.ts
+++ b/extension/server/src/providers/project/exportInterfaces.ts
@@ -33,10 +33,11 @@ export function getInterfaces(): APIInterface[] {
 							if (entryFunction) {
 
 								// We assume the file name is the name of the object
-								entryFunction.keyword[`EXTPGM`] = `'${objectName}'`;
+								const useKeywords = {...entryFunction.keyword};
+								useKeywords[`EXTPGM`] = `'${objectName}'`;
 
 								const prototype = [
-									`dcl-pr ${entryFunction.name} ${prettyKeywords(entryFunction.keyword)};`,
+									`dcl-pr ${entryFunction.name} ${prettyKeywords(useKeywords, true)};`,
 									...entryFunction.subItems.map(subItem =>
 										`  ${subItem.name} ${prettyKeywords(subItem.keyword)};`
 									),
@@ -68,10 +69,11 @@ export function getInterfaces(): APIInterface[] {
 									return; // Skip user test functions
 								}
 
-								proc.keyword[`EXTPROC`] = `'${proc.name.toUpperCase()}'`;
+								const useKeywords = {...proc.keyword};
+								useKeywords[`EXTPROC`] = `'${proc.name.toUpperCase()}'`;
 
 								const prototype = [
-									`dcl-pr ${proc.name} ${prettyKeywords(proc.keyword)};`,
+									`dcl-pr ${proc.name} ${prettyKeywords(useKeywords, true)};`,
 									...proc.subItems.map(subItem =>
 										`  ${subItem.name} ${prettyKeywords(subItem.keyword)};`
 									),


### PR DESCRIPTION
* Exclude specific test functions from the completion provider to streamline the development experience when working locally.
* Fix issue with `export` keyword showing up in auto-import prototypes
* Don't show both procedure and prototype at the same time in completion provider