### PR TITLE
Improve hover provider to utilize existing documentation

### DIFF
--- a/extension/server/src/providers/hover.ts
+++ b/extension/server/src/providers/hover.ts
@@ -4,7 +4,7 @@ import Parser from "../../../../language/parser";
 import { URI } from 'vscode-uri';
 import { Keywords } from '../../../../language/parserTypes';
 
-export default async function hoverProvider(params: HoverParams): Promise<Hover|undefined> {
+export default async function hoverProvider(params: HoverParams): Promise<Hover | undefined> {
 	const currentPath = params.textDocument.uri;
 	const currentLine = params.position.line;
 	const document = documents.get(currentPath);
@@ -15,74 +15,65 @@ export default async function hoverProvider(params: HoverParams): Promise<Hover|
 			const word = getWordRangeAtPosition(document, params.position);
 			if (!word) return;
 
-			const procedure = doc.procedures.find(proc => proc.name.toUpperCase() === word.toUpperCase());
+			let symbol = doc.findDefinition(currentLine, word);
 
-			if (procedure) {
-				let markdown = ``;
-				let returnValue = `void`
+			if (symbol) {
+				if (symbol.type === `procedure`) {
 
-				let returnKeywords: Keywords = {
-					...procedure.keyword,
-				};
-				delete returnKeywords[`EXTPROC`];
-
-				if (Object.keys(returnKeywords).length > 0) returnValue = prettyKeywords(returnKeywords);
-
-				const returnTag = procedure.tags.find(tag => tag.tag === `return`);
-				const deprecatedTag = procedure.tags.find(tag => tag.tag === `deprecated`);
-
-				// Deprecated notice
-				if (deprecatedTag) {
-					markdown += `**Deprecated:** ${deprecatedTag.content}\n\n`;
-				}
-
-				// Formatted code
-				markdown += `\`\`\`vb\n${procedure.name}(`;
-
-				if (procedure.subItems.length > 0) {
-					markdown += `\n  ${procedure.subItems.map(parm => `${parm.name}: ${prettyKeywords(parm.keyword)}`).join(`,\n  `)}\n`;
-				}
-
-				markdown += `): ${returnValue}\n\`\`\` \n`;
-
-				const titleTag = procedure.tags.find(tag => tag.tag === `title`);
-				const descriptionTag = procedure.tags.find(tag => tag.tag === `description`);
-
-				const header = [titleTag ? titleTag.content : undefined, descriptionTag ? descriptionTag.content : undefined].filter(x => x).join(` — `);
-
-				// Header
-				markdown += `${header}\n\n`;
-
-				// Params
-				markdown += procedure.subItems.map((parm) => `*@param* \`${parm.name.replace(new RegExp(`\\*`, `g`), `\\*`)}\` ${parm.tags.find(t => t.tag === `description`)?.content || ``}`).join(`\n\n`);
-
-				// Return value
-				if (returnTag) {
-					markdown += `\n\n*@returns* ${returnTag.content}`;
-				}
-
-				if (procedure.position && currentPath !== procedure.position.path) {
-					markdown += `\n\n*@file* \`${procedure.position.path}:${procedure.position.range.line+1}\``;
-				}
-				
-				return {
-					contents: {
-						kind: MarkupKind.Markdown,
-						value: markdown
+					// If a symbol is found, but there are no docs,
+					// maybe the docs exist on a matching prototype?
+					if (symbol.tags.length === 0) {
+						const withDocs = doc.findAll(word).find(p => p.type === `procedure` && p.tags.length > 0);
+						if (withDocs) {
+							symbol = withDocs;
+						}
 					}
-				};
-			} else {
-				// If they're inside of a procedure, let's get the stuff from there too
-				let theVariable = doc.findDefinition(currentLine, word);
 
-				if (theVariable) {
-					// Variable definition found
-					const refs = theVariable.references.length;
-										
-					let markdown = `\`${theVariable.name} ${prettyKeywords(theVariable.keyword)}\` (${refs} reference${refs === 1 ? `` : `s`})`;
+					let markdown = ``;
+					let returnValue = `void`
 
-					if (theVariable.position && currentPath !== theVariable.position.path) {
-						markdown += `\n\n*@file* \`${theVariable.position.path}:${theVariable.position.range.line+1}\``;
+					let returnKeywords: Keywords = {
+						...symbol.keyword,
+					};
+					delete returnKeywords[`EXTPROC`];
+
+					if (Object.keys(returnKeywords).length > 0) returnValue = prettyKeywords(returnKeywords);
+
+					const returnTag = symbol.tags.find(tag => tag.tag === `return`);
+					const deprecatedTag = symbol.tags.find(tag => tag.tag === `deprecated`);
+
+					// Deprecated notice
+					if (deprecatedTag) {
+						markdown += `**Deprecated:** ${deprecatedTag.content}\n\n`;
+					}
+
+					// Formatted code
+					markdown += `\`\`\`vb\n${symbol.name}(`;
+
+					if (symbol.subItems.length > 0) {
+						markdown += `\n  ${symbol.subItems.map(parm => `${parm.name}: ${prettyKeywords(parm.keyword)}`).join(`,\n  `)}\n`;
+					}
+
+					markdown += `): ${returnValue}\n\`\`\` \n`;
+
+					const titleTag = symbol.tags.find(tag => tag.tag === `title`);
+					const descriptionTag = symbol.tags.find(tag => tag.tag === `description`);
+
+					const header = [titleTag ? titleTag.content : undefined, descriptionTag ? descriptionTag.content : undefined].filter(x => x).join(` — `);
+
+					// Header
+					markdown += `${header}\n\n`;
+
+					// Params
+					markdown += symbol.subItems.map((parm) => `*@param* \`${parm.name.replace(new RegExp(`\\*`, `g`), `\\*`)}\` ${parm.tags.find(t => t.tag === `description`)?.content || ``}`).join(`\n\n`);
+
+					// Return value
+					if (returnTag) {
+						markdown += `\n\n*@returns* ${returnTag.content}`;
+					}
+
+					if (symbol.position && currentPath !== symbol.position.path) {
+						markdown += `\n\n*@file* \`${symbol.position.path}:${symbol.position.range.line + 1}\``;
 					}
 
 					return {
@@ -91,41 +82,57 @@ export default async function hoverProvider(params: HoverParams): Promise<Hover|
 							value: markdown
 						}
 					};
-
 				} else {
-					const lineContent = document.getText(Range.create(currentLine, 0, currentLine, 200));
+					// Variable definition found
+					const refs = symbol.references.length;
 
-					const includeDirective = Parser.getIncludeFromDirective(lineContent);
-					
-					if (includeDirective && parser.includeFileFetch) {
-						const include = await parser.includeFileFetch(currentPath, includeDirective);
-						let displayName = includeDirective;
+					let markdown = `\`${symbol.name} ${prettyKeywords(symbol.keyword)}\` (${refs} reference${refs === 1 ? `` : `s`})`;
 
-						if (include.found && include.uri) {
-							const foundUri = URI.parse(include.uri);
+					if (symbol.position && currentPath !== symbol.position.path) {
+						markdown += `\n\n*@file* \`${symbol.position.path}:${symbol.position.range.line + 1}\``;
+					}
 
-							if (foundUri.scheme === `member`) {
-								const lastIndex = foundUri.path.lastIndexOf(`.`);
-								if (lastIndex >= 0) {
-									displayName = foundUri.path.substring(0, lastIndex);
-								} else {
-									displayName = foundUri.path;
-								}
+					return {
+						contents: {
+							kind: MarkupKind.Markdown,
+							value: markdown
+						}
+					};
+				}
 
-								if (displayName.startsWith(`/`)) displayName = displayName.substring(1);
+			} else {
+				const lineContent = document.getText(Range.create(currentLine, 0, currentLine, 200));
 
+				const includeDirective = Parser.getIncludeFromDirective(lineContent);
+
+				if (includeDirective && parser.includeFileFetch) {
+					const include = await parser.includeFileFetch(currentPath, includeDirective);
+					let displayName = includeDirective;
+
+					if (include.found && include.uri) {
+						const foundUri = URI.parse(include.uri);
+
+						if (foundUri.scheme === `member`) {
+							const lastIndex = foundUri.path.lastIndexOf(`.`);
+							if (lastIndex >= 0) {
+								displayName = foundUri.path.substring(0, lastIndex);
 							} else {
 								displayName = foundUri.path;
 							}
-						}
 
-						return {
-							contents: {
-								kind: MarkupKind.Markdown,
-								value: (include.found ? `\`${displayName}\`` : includeDirective) + ` (${include.found ? `found` : `not found`})`
-							}
-						};
+							if (displayName.startsWith(`/`)) displayName = displayName.substring(1);
+
+						} else {
+							displayName = foundUri.path;
+						}
 					}
+
+					return {
+						contents: {
+							kind: MarkupKind.Markdown,
+							value: (include.found ? `\`${displayName}\`` : includeDirective) + ` (${include.found ? `found` : `not found`})`
+						}
+					};
 				}
 			}
 		}

--- a/language/models/cache.ts
+++ b/language/models/cache.ts
@@ -177,11 +177,7 @@ export default class Cache {
   findAll(name: string): Declaration[] {
     name = name.toUpperCase();
     const symbols = this.symbolRegister.get(name);
-    if (symbols) {
-      return Array.isArray(symbols) ? symbols : [symbols];
-    }
-
-    return [];
+    return symbols || [];
   }
 
   public findProcedurebyLine(lineNumber: number): Declaration | undefined {


### PR DESCRIPTION
Fixes #417, where when hovering over a procedure implementation with no docs, but with docs defined in the prototype, nothing would be shown.