### PR TITLE
Only add SQL reference for valid tokens

### DIFF
--- a/language/parser.ts
+++ b/language/parser.ts
@@ -1240,7 +1240,7 @@ export default class Parser {
                   (inBlock || isContinued) &&  // If this is true, usually means next word is the object
                   (part === `INTO` ? parts[index-1] === `INSERT` : true) // INTO is special, as it can be used in both SELECT and INSERT
                 ) {
-                  if (index >= 0 && (index+1) < parts.length && !ignoredWords.includes(parts[index+1])) {
+                  if (index >= 0 && (index+1) < parts.length && tokens[index+1].type === `word` && !ignoredWords.includes(parts[index+1])) {
 
                     const qualifiedObjectPath = cleanupObjectRef(index+1);
 


### PR DESCRIPTION
Ensure SQL references are only added when the token is a valid word. Added a test case for SQL prepare reference to validate this behavior.

I saw this error in Source Orbit a lot during testing:

```
FILE.SQLRPGLE:123 - No object found for reference ':'
```

And it was because of this bug.