### PR TITLE
Fix offset reference resolver to improve depth handling

### DIFF
--- a/language/models/cache.ts
+++ b/language/models/cache.ts
@@ -297,6 +297,14 @@ export default class Cache {
         for (const subItem of def.subItems) {
           possibleRef = subItem.references.some(r => r.uri === baseUri && offset >= r.offset.start && offset <= r.offset.end);
           if (possibleRef) return subItem;
+
+          // Do one more level deep
+          if (subItem.subItems.length > 0) {
+            for (const subSubItem of subItem.subItems) {
+              possibleRef = subSubItem.references.some(r => r.uri === baseUri && offset >= r.offset.start && offset <= r.offset.end);
+              if (possibleRef) return subSubItem;
+            }
+          }
         }
       }
 

--- a/tests/suite/references.test.ts
+++ b/tests/suite/references.test.ts
@@ -156,6 +156,28 @@ test("references_7", async () => {
   expect(varColors.references.length).toEqual(1);
 });
 
+test("reference from file (#406)", async () => {
+  const lines = [
+    `**free`,
+    `dcl-s var1 varchar(20);`,
+    ``,
+    `dcl-f department keyed;`,
+    ``,
+    `deptname = 'scoobydo';`,
+    ``,
+    `dsply deptname;`,
+  ].join(`\n`);
+
+  const cache = await parser.getDocs(uri, lines, {ignoreCache: true, collectReferences: true});
+
+  const deptname = cache.find(`deptname`);
+  expect(deptname.name).toEqual(`DEPTNAME`);
+  expect(deptname.references.length).toEqual(2);
+
+  const reference = Cache.referenceByOffset(uri, cache, lines.indexOf(`deptname`));
+  expect(reference).toMatchObject(deptname);
+});
+
 test("references_8", async () => {
   const lines = [
     `**free`,


### PR DESCRIPTION
Enhance the offset reference resolver to check for references in nested sub-items. Add a test case to validate the functionality for a specific reference scenario.

This specifically covers the use of file defintions, record formats and their fields.

Fixed #406