### PR TITLE
Allow symbols to be defined in free-format

### DIFF
--- a/language/parser.ts
+++ b/language/parser.ts
@@ -891,51 +891,47 @@ export default class Parser {
 
           case `DCL-S`:
             if (parts.length > 1) {
-              if (currentItem === undefined) {
-                currentItem = new Declaration(`variable`);
-                currentItem.name = partsLower[1];
-                currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
-                currentItem.tags = currentTags;
+              currentItem = new Declaration(`variable`);
+              currentItem.name = partsLower[1];
+              currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
+              currentItem.tags = currentTags;
 
-                currentItem.position = {
-                  path: fileUri,
-                  range: tokens[1].range
-                };
+              currentItem.position = {
+                path: fileUri,
+                range: tokens[1].range
+              };
 
-                currentItem.range = {
-                  start: currentStmtStart.line,
-                  end: lineNumber
-                };
+              currentItem.range = {
+                start: currentStmtStart.line,
+                end: lineNumber
+              };
 
-                scope.addSymbol(currentItem);
-                resetDefinition = true;
-              }
+              scope.addSymbol(currentItem);
+              resetDefinition = true;
             }
             break;
 
           case `DCL-ENUM`:
-            if (currentItem === undefined) {
-              if (parts.length > 1) {
-                currentItem = new Declaration(`constant`);
-                currentItem.name = partsLower[1];
-                currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
+            if (parts.length > 1) {
+              currentItem = new Declaration(`constant`);
+              currentItem.name = partsLower[1];
+              currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
 
-                currentItem.position = {
-                  path: fileUri,
-                  range: tokens[1].range
-                };
+              currentItem.position = {
+                path: fileUri,
+                range: tokens[1].range
+              };
 
-                currentItem.range = {
-                  start: currentStmtStart.line,
-                  end: currentStmtStart.line
-                };
+              currentItem.range = {
+                start: currentStmtStart.line,
+                end: currentStmtStart.line
+              };
 
-                currentItem.readParms = true;
+              currentItem.readParms = true;
 
-                currentGroup = `constants`;
+              currentGroup = `constants`;
 
-                currentDescription = [];
-              }
+              currentDescription = [];
             }
             break;
 

--- a/tests/suite/basics.test.ts
+++ b/tests/suite/basics.test.ts
@@ -1877,22 +1877,59 @@ test('correct ranges (#427)', async () => {
   expect(constants[3].keyword[`CONST`]).toBe(`9`);
 });
 
-// test('scoobydo', async () => {
-//   const content = await getFileContent(path.join(__dirname, `..`, `rpgle`, `testing.rpgle`));
-//   const lines = content.split(/\r?\n/);
-//   const cache = await parser.getDocs(uri, content, { ignoreCache: true, withIncludes: false });
+test('that symbols can be defined correctly', async () => {
+  const lines = [
+    ``,
+    `     D SAMPLEPG        Ds                  Qualified  `,
+    `       dcl-s myprogramText char(20);`,
+    `       dcl-s  sampleDcl               char(2);`,
+    `       dcl-enum ENUMTEST qualified;`,
+    `         CONSTANT1 value1;`,
+    `         CONSTANT2 value2;`,
+    `       end-enum;`,
+    `       `,
+    `       dcl-proc testing123 ;`,
+    `        dcl-pi *n ;`,
+    `        end-pi;`,
+    `         `,
+    `       end-proc;`,
+    `     `,
+  ].join(`\n`);
 
-//   const kill = cache.findAll(`kill`);
-  
-//   const killPrototype = kill[0];
-//   expect(killPrototype.name).toBe(`kill`);
-//   expect(killPrototype.prototype).toBeTruthy();
-//   expect(killPrototype.range.start).toBe(71);
-//   expect(killPrototype.range.end).toBe(74);
+  const cache = await parser.getDocs(uri, lines, { ignoreCache: true, withIncludes: false, collectReferences: true });
 
-//   const killProc = kill[1];
-//   expect(killProc.name).toBe(`kill`);
-//   expect(killProc.prototype).toBeFalsy();
-//   expect(killProc.range.start).toBe(741);
-//   expect(killProc.range.end).toBe(761);  
-// });
+  expect(cache.structs.length).toBe(1);
+  expect(cache.constants.length).toBe(1);
+  expect(cache.variables.length).toBe(2);
+  expect(cache.procedures.length).toBe(1);
+});
+
+test('that mixed symbols can be defined correctly', async () => {
+  const lines = [
+    ``,
+    ``,
+    `     D SAMPLEPG        Ds                  Qualified`,
+    `     F TEST  `,
+    `       dcl-s myprogramText char(20);`,
+    `       dcl-s  sampleDcl               char(2);`,
+    `       dcl-enum ENUMTEST qualified;`,
+    `         CONSTANT1 value1;`,
+    `         CONSTANT2 value2;`,
+    `       end-enum;`,
+    `       `,
+    `       dcl-proc testing123 ;`,
+    `        dcl-pi *n ;`,
+    `        end-pi;`,
+    `         `,
+    `       end-proc;`,
+    `     `,
+  ].join(`\n`);
+
+  const cache = await parser.getDocs(uri, lines, { ignoreCache: true, withIncludes: false, collectReferences: true });
+
+  expect(cache.structs.length).toBe(1);
+  expect(cache.files.length).toBe(1);
+  expect(cache.constants.length).toBe(1);
+  expect(cache.variables.length).toBe(2);
+  expect(cache.procedures.length).toBe(1);
+});


### PR DESCRIPTION
Enhance the parser to support symbol definitions in free-format, ensuring correct handling of declarations and enumerations. Add tests to verify the functionality.