### PR TITLE
Fix comment parsing issue in the compiler

### DIFF
--- a/language/parser.ts
+++ b/language/parser.ts
@@ -602,7 +602,7 @@ export default class Parser {
         lineIsFree = false;
         lineNumber += 1;
 
-        if (baseLine.startsWith(`**`)) {
+        if (baseLine.startsWith(`**`) && baseLine[2] !== `*`) {
           // Usually is **FREE
           if (lineNumber === 0) continue;
           // After compile time data, we're done
@@ -1484,8 +1484,7 @@ export default class Parser {
             }
 
             switch (cSpec.opcode && cSpec.opcode.value) {
-            case `BEGSR`:
-              
+            case `BEGSR`:  
               if (cSpec.factor1 && !scope.find(cSpec.factor1.value, `subroutine`)) {
                 currentItem = new Declaration(`subroutine`);
                 currentItem.name = cSpec.factor1.value;

--- a/tests/suite/fixed.test.ts
+++ b/tests/suite/fixed.test.ts
@@ -1426,3 +1426,28 @@ test('incorrect range on prototypes and procedures (#412)', async () => {
   expect(procRange.start).toBeGreaterThan(prRange.end);
   expect(procRange.end).toBeGreaterThan(procRange.start);
 });
+
+test('missing subroutines #443', async () => {
+  const lines = [
+    `     C     PROCRC        BEGSR`,
+    `     C*`,
+    `     C                   ENDSR`,
+    `     C**************************`,
+    `     C     ADDSUB        BEGSR`,
+    `     C                   MOVE      #4XDSP        XHXDSP                         O/G LINE`,
+    `******* USE CLASS CODE FROM OVERRIDDEN CLASS!`,
+    `     C     LDACL         IFEQ      'B'`,
+    `     C                   ENDIF`,
+    `     C*`,
+    `     C                   ENDSR`,
+  ].join(`\n`);
+
+  const cache = await parser.getDocs(uri, lines, {withIncludes: true, ignoreCache: true});
+
+  expect(cache).toBeDefined();
+
+  const subroutines = cache.subroutines;
+  expect(subroutines.length).toBe(2);
+  expect(subroutines[0].name).toBe('PROCRC');
+  expect(subroutines[1].name).toBe('ADDSUB');
+});


### PR DESCRIPTION
Resolve a problem where comments were incorrectly interpreted as compiler directives, ensuring proper handling of comment lines.