### PR TITLE
Implement fix to use **free after line one

### DIFF
--- a/language/parser.ts
+++ b/language/parser.ts
@@ -427,7 +427,7 @@ export default class Parser {
       let lineNumber = -1;
       let lineIndex = 0;
 
-      let isFullyFree = lines[0].toUpperCase().startsWith(`**FREE`);
+      let isFullyFree = false;
       let lineIsFree = false;
 
       /** Used for handling multiline statements */
@@ -643,9 +643,17 @@ export default class Parser {
         lineNumber += 1;
 
         if (baseLine.startsWith(`**`) && baseLine[2] !== `*`) {
-          // Usually is **FREE
-          if (lineNumber === 0) continue;
-          // After compile time data, we're done
+          if (baseLine.toLowerCase() === `**free`) {
+            // **free only works when set on the first line
+            if (lineNumber === 0) {
+              isFullyFree = true;
+            }
+
+            // But it can be put on any other line and ignored.
+            continue;
+          }
+          
+          // If it's something else, we assume it's compile time data
           else break;
         }
 

--- a/tests/suite/basics.test.ts
+++ b/tests/suite/basics.test.ts
@@ -1956,3 +1956,28 @@ test('range issue #453 (full source)', async () => {
 
   expect(cache).toBeDefined();
 });
+
+test('**free after first line (#451)', async () => {
+  const lines = [
+    `       //**                                                           ***`,
+    ``,
+    `**FREE`,
+    `       //****************************************************************`,
+    `       //**    `,
+    ` `,
+    `       dcl-s txtMsg char(10);   `,
+    `                                                   `,
+    `       dcl-ds person;`,
+    `         name varchar(30);`,
+    `         age int(3);`,
+    `       end-Ds;`,
+    ``,
+    `       return;`,
+  ].join(`\n`);
+
+  const cache = await parser.getDocs(uri, lines, { ignoreCache: true, withIncludes: false, collectReferences: true });
+
+  expect(cache).toBeDefined();
+
+  expect(cache.find(`txtMsg`)).toBeDefined();
+});


### PR DESCRIPTION
### Changes

This pull request updates the handling of the `**FREE` directive in the parser and adds a new test to ensure correct behavior. The most important changes are grouped below:

Parser logic improvements:

* Changed the parser so that the `**FREE` directive is only recognized if it appears on the first line; if it appears elsewhere, it is ignored. This makes the parser more robust and aligns it with expected language rules.

Test coverage:

* Added a new test case `**free after first line (#451)` in `basics.test.ts` to verify that `**FREE` is ignored when not on the first line, ensuring the parser's behavior matches the updated logic.
