### PR TITLE
Fix offset issue

### DIFF
--- a/extension/server/src/connection.ts
+++ b/extension/server/src/connection.ts
@@ -24,10 +24,48 @@ connection.onDidChangeWatchedFiles((params: DidChangeWatchedFilesParams) => {
 	watchedFilesChangeEvent.forEach(editEvent => editEvent(params));
 })
 
-function logWithTimestamp(message: string) {
+// Log level constants and names
+export const LogLevel = {
+	NONE: 0,
+	ERROR: 1,
+	WARN: 2,
+	INFO: 3,
+	DEBUG: 4
+};
+
+const LOG_LEVEL_NAMES = ['NONE', 'ERROR', 'WARN', 'INFO', 'DEBUG'];
+
+let logLevel: number = LogLevel.INFO; // Default to INFO
+
+export function setLogLevel(level: number) {
+	logLevel = Math.max(LogLevel.NONE, Math.min(LogLevel.DEBUG, level)); // Clamp between 0-4
+	const levelName = LOG_LEVEL_NAMES[logLevel] || 'UNKNOWN';
+	logWithTimestamp(`Log level set to ${logLevel} (${levelName})`, LogLevel.NONE);
+}
+
+export async function initializeLogLevel() {
+	try {
+		const config = await connection.workspace.getConfiguration('vscode-rpgle');
+		const logLevelString = config?.logLevel || 'info';
+
+		// Map string to numeric level using LOG_LEVEL_NAMES
+		const levelIndex = LOG_LEVEL_NAMES.findIndex(name => name.toLowerCase() === logLevelString.toLowerCase());
+		const level = levelIndex !== -1 ? levelIndex : LogLevel.INFO;
+
+		setLogLevel(level);
+	} catch (e) {
+		logWithTimestamp(`Failed to read log level setting, using default of INFO`, LogLevel.WARN);
+		setLogLevel(LogLevel.INFO);
+	}
+}
+
+export function logWithTimestamp(message: string, level: number = LogLevel.INFO) {
+	if (level > logLevel) return;
+
 	const now = new Date();
 	const timestamp = now.toTimeString().split(' ')[0] + '.' + now.getMilliseconds().toString().padStart(3, '0');
-	console.log(`[${timestamp}] ${message}`);
+	const levelName = LOG_LEVEL_NAMES[level] || 'LOG';
+	console.log(`[${timestamp}] [${levelName}] ${message}`);
 }
 
 export async function validateUri(stringUri: string, scheme = ``) {
@@ -37,22 +75,22 @@ export async function validateUri(stringUri: string, scheme = ``) {
 	const possibleCachedFile = findFile(stringUri, scheme);
 	if (possibleCachedFile) {
 		const duration = Date.now() - startTime;
-		logWithTimestamp(`URI validation: ${stringUri} (${duration}ms, local cache)`);
+		logWithTimestamp(`URI validation: ${stringUri} (${duration}ms, local cache)`, LogLevel.DEBUG);
 		return possibleCachedFile;
 	}
 
-	logWithTimestamp(`URI validation: ${stringUri} (requesting from server...)`);
+	logWithTimestamp(`URI validation: ${stringUri} (requesting from server...)`, LogLevel.DEBUG);
 
 	// Then reach out to the extension to find it
 	const uri: string|undefined = await connection.sendRequest("getUri", stringUri);
 	const duration = Date.now() - startTime;
 
 	if (uri) {
-		logWithTimestamp(`URI validation: ${stringUri} -> ${uri} (${duration}ms, server)`);
+		logWithTimestamp(`URI validation: ${stringUri} -> ${uri} (${duration}ms, server)`, LogLevel.INFO);
 		return uri;
 	}
 
-	logWithTimestamp(`URI validation: ${stringUri} (${duration}ms, NOT FOUND)`);
+	logWithTimestamp(`URI validation: ${stringUri} (${duration}ms, NOT FOUND)`, LogLevel.WARN);
 	return;
 }
 
@@ -67,11 +105,11 @@ export async function getFileRequest(uri: string, skipDebounce: boolean = false)
 	const localCacheDoc = documents.get(uri);
 	if (localCacheDoc) {
 		const duration = Date.now() - startTime;
-		logWithTimestamp(`File fetch: ${fileName} (${duration}ms, local documents cache)`);
+		logWithTimestamp(`File fetch: ${fileName} (${duration}ms, local documents cache)`, LogLevel.DEBUG);
 		return localCacheDoc.getText();
 	}
 
-	logWithTimestamp(`File fetch: ${fileName} (requesting from server...)`);
+	logWithTimestamp(`File fetch: ${fileName} (requesting from server...)`, LogLevel.DEBUG);
 
 	// If this is an include file fetch, track it to skip debounce
 	if (skipDebounce) {
@@ -84,12 +122,17 @@ export async function getFileRequest(uri: string, skipDebounce: boolean = false)
 		const duration = Date.now() - startTime;
 
 		if (body) {
-			logWithTimestamp(`File fetch: ${fileName} (${duration}ms, ${body.length} bytes from server)`);
+			logWithTimestamp(`File fetch: ${fileName} (${duration}ms, ${body.length} bytes from server)`, LogLevel.INFO);
 			// TODO.. cache it?
 			return body;
 		}
 
-		logWithTimestamp(`File fetch: ${fileName} (${duration}ms, NOT FOUND)`);
+		logWithTimestamp(`File fetch: ${fileName} (${duration}ms, NOT FOUND)`, LogLevel.WARN);
+		return;
+	} catch (error) {
+		const duration = Date.now() - startTime;
+		logWithTimestamp(`File fetch: ${fileName} (${duration}ms, ERROR: ${error})`, LogLevel.ERROR);
+		console.error(`File fetch error details for ${uri}:`, error);
 		return;
 	} finally {
 		// Always clean up tracking
@@ -112,29 +155,29 @@ export async function memberResolve(baseUri: string, member: string, file: strin
 	if (resolvedMembers[normalizedBaseUri] && resolvedMembers[normalizedBaseUri][fileKey]) {
 		const cached = resolvedMembers[normalizedBaseUri][fileKey];
 		const duration = Date.now() - startTime;
-		logWithTimestamp(`Member resolve CACHE HIT: ${file}/${member} -> ${cached.library}/${cached.file}/${cached.name} (${duration}ms)`);
+		logWithTimestamp(`Member resolve CACHE HIT: ${file}/${member} -> ${cached.library}/${cached.file}/${cached.name} (${duration}ms)`, LogLevel.DEBUG);
 		return cached;
 	}
 
-	logWithTimestamp(`Member resolve CACHE MISS: ${file}/${member} (baseUri=${normalizedBaseUri})`);
+	logWithTimestamp(`Member resolve CACHE MISS: ${file}/${member} (baseUri=${normalizedBaseUri})`, LogLevel.DEBUG);
 
 	try {
 		const resolvedMember = await queue.add(() => {return connection.sendRequest("memberResolve", [member, file])}) as IBMiMember|undefined;
 		const duration = Date.now() - startTime;
 
 		if (resolvedMember) {
-			logWithTimestamp(`Member resolve SUCCESS: ${file}/${member} -> ${resolvedMember.library}/${resolvedMember.file}/${resolvedMember.name} (${duration}ms)`);
+			logWithTimestamp(`Member resolve SUCCESS: ${file}/${member} -> ${resolvedMember.library}/${resolvedMember.file}/${resolvedMember.name} (${duration}ms)`, LogLevel.DEBUG);
 
 			if (!resolvedMembers[normalizedBaseUri]) resolvedMembers[normalizedBaseUri] = {};
 			resolvedMembers[normalizedBaseUri][fileKey] = resolvedMember;
 		} else {
-			logWithTimestamp(`Member resolve NOT FOUND: ${file}/${member} (${duration}ms)`);
+			logWithTimestamp(`Member resolve NOT FOUND: ${file}/${member} (${duration}ms)`, LogLevel.WARN);
 		}
 
 		return resolvedMember;
 	} catch (e) {
 		const duration = Date.now() - startTime;
-		logWithTimestamp(`Member resolve ERROR: ${file}/${member} (${duration}ms)`);
+		logWithTimestamp(`Member resolve ERROR: ${file}/${member} (${duration}ms)`, LogLevel.ERROR);
 		console.log(JSON.stringify({baseUri, member, file}));
 		console.log(e);
 	}
@@ -153,12 +196,12 @@ export async function streamfileResolve(baseUri: string, base: string[]): Promis
 		const cached = resolvedStreamfiles[normalizedBaseUri][baseString];
 		const duration = Date.now() - startTime;
 		const requestingFile = normalizedBaseUri.split('/').pop() || normalizedBaseUri;
-		logWithTimestamp(`Streamfile resolve CACHE HIT: ${base[0]} (requesting: ${requestingFile}) -> ${cached} (${duration}ms)`);
+		logWithTimestamp(`Streamfile resolve CACHE HIT: ${base[0]} (requesting: ${requestingFile}) -> ${cached} (${duration}ms)`, LogLevel.DEBUG);
 		return cached;
 	}
 
 	const requestingFile = normalizedBaseUri.split('/').pop() || normalizedBaseUri;
-	logWithTimestamp(`Streamfile resolve CACHE MISS: ${base[0]} (requesting: ${requestingFile})`);
+	logWithTimestamp(`Streamfile resolve CACHE MISS: ${base[0]} (requesting: ${requestingFile})`, LogLevel.DEBUG);
 
 	const workspace = await getWorkspaceFolder(baseUri);
 
@@ -169,18 +212,18 @@ export async function streamfileResolve(baseUri: string, base: string[]): Promis
 		const duration = Date.now() - startTime;
 
 		if (resolvedPath) {
-			logWithTimestamp(`Streamfile resolve SUCCESS: ${base[0]} (requesting: ${requestingFile}) -> ${resolvedPath} (${duration}ms)`);
+			logWithTimestamp(`Streamfile resolve SUCCESS: ${base[0]} (requesting: ${requestingFile}) -> ${resolvedPath} (${duration}ms)`, LogLevel.DEBUG);
 
 			if (!resolvedStreamfiles[normalizedBaseUri]) resolvedStreamfiles[normalizedBaseUri] = {};
 			resolvedStreamfiles[normalizedBaseUri][baseString] = resolvedPath;
 		} else {
-			logWithTimestamp(`Streamfile resolve NOT FOUND: ${base[0]} (requesting: ${requestingFile}) (${duration}ms)`);
+			logWithTimestamp(`Streamfile resolve NOT FOUND: ${base[0]} (requesting: ${requestingFile}) (${duration}ms)`, LogLevel.WARN);
 		}
 
 		return resolvedPath;
 	} catch (e) {
 		const duration = Date.now() - startTime;
-		logWithTimestamp(`Streamfile resolve ERROR: ${base[0]} (requesting: ${requestingFile}) (${duration}ms)`);
+		logWithTimestamp(`Streamfile resolve ERROR: ${base[0]} (requesting: ${requestingFile}) (${duration}ms)`, LogLevel.ERROR);
 		console.log(JSON.stringify({baseUri, base, paths}));
 		console.log(e);
 	}

--- a/extension/server/src/connection.ts
+++ b/extension/server/src/connection.ts
@@ -24,6 +24,16 @@ connection.onDidChangeWatchedFiles((params: DidChangeWatchedFilesParams) => {
 	watchedFilesChangeEvent.forEach(editEvent => editEvent(params));
 })
 
+/**
+ * Extracts a clean, decoded filename from a URI for display in logs
+ * Handles URL encoding (e.g., %23 -> #) and removes query parameters
+ */
+export function getDisplayName(uri: string): string {
+	const withoutQuery = uri.split('?')[0];
+	const fileName = withoutQuery.split('/').pop() || uri;
+	return decodeURIComponent(fileName);
+}
+
 // Log level constants and names
 export const LogLevel = {
 	NONE: 0,
@@ -99,7 +109,7 @@ export const filesBeingFetchedForIncludes = new Set<string>();
 
 export async function getFileRequest(uri: string, skipDebounce: boolean = false) {
 	const startTime = Date.now();
-	const fileName = uri.split('/').pop() || uri;
+	const fileName = getDisplayName(uri);
 
 	// First, check if it's local
 	const localCacheDoc = documents.get(uri);
@@ -159,7 +169,8 @@ export async function memberResolve(baseUri: string, member: string, file: strin
 		return cached;
 	}
 
-	logWithTimestamp(`Member resolve CACHE MISS: ${file}/${member} (baseUri=${normalizedBaseUri})`, LogLevel.DEBUG);
+	const baseFileName = getDisplayName(normalizedBaseUri);
+	logWithTimestamp(`Member resolve CACHE MISS: ${file}/${member} (baseUri=${baseFileName})`, LogLevel.DEBUG);
 
 	try {
 		const resolvedMember = await queue.add(() => {return connection.sendRequest("memberResolve", [member, file])}) as IBMiMember|undefined;
@@ -195,12 +206,12 @@ export async function streamfileResolve(baseUri: string, base: string[]): Promis
 	if (resolvedStreamfiles[normalizedBaseUri] && resolvedStreamfiles[normalizedBaseUri][baseString]) {
 		const cached = resolvedStreamfiles[normalizedBaseUri][baseString];
 		const duration = Date.now() - startTime;
-		const requestingFile = normalizedBaseUri.split('/').pop() || normalizedBaseUri;
+		const requestingFile = getDisplayName(normalizedBaseUri);
 		logWithTimestamp(`Streamfile resolve CACHE HIT: ${base[0]} (requesting: ${requestingFile}) -> ${cached} (${duration}ms)`, LogLevel.DEBUG);
 		return cached;
 	}
 
-	const requestingFile = normalizedBaseUri.split('/').pop() || normalizedBaseUri;
+	const requestingFile = getDisplayName(normalizedBaseUri);
 	logWithTimestamp(`Streamfile resolve CACHE MISS: ${base[0]} (requesting: ${requestingFile})`, LogLevel.DEBUG);
 
 	const workspace = await getWorkspaceFolder(baseUri);

--- a/extension/server/src/connection.ts
+++ b/extension/server/src/connection.ts
@@ -152,25 +152,23 @@ export async function getFileRequest(uri: string, skipDebounce: boolean = false)
 	}
 }
 
-export let resolvedMembers: {[baseUri: string]: {[fileKey: string]: IBMiMember}} = {};
-export let resolvedStreamfiles: {[baseUri: string]: {[fileKey: string]: string}} = {};
+// Global caches - not scoped per file since library list is connection-level
+export let resolvedMembers: {[fileKey: string]: IBMiMember} = {};
+export let resolvedStreamfiles: {[fileKey: string]: string} = {};
 
 export async function memberResolve(baseUri: string, member: string, file: string): Promise<IBMiMember|undefined> {
-	// Normalize baseUri by removing query parameters to ensure consistent cache keys
-	const normalizedBaseUri = baseUri.split('?')[0];
 	const fileKey = file+member;
 	const startTime = Date.now();
 
-	// Check cache
-	if (resolvedMembers[normalizedBaseUri] && resolvedMembers[normalizedBaseUri][fileKey]) {
-		const cached = resolvedMembers[normalizedBaseUri][fileKey];
+	// Check global cache
+	if (resolvedMembers[fileKey]) {
+		const cached = resolvedMembers[fileKey];
 		const duration = Date.now() - startTime;
 		logWithTimestamp(`Member resolve CACHE HIT: ${file}/${member} -> ${cached.library}/${cached.file}/${cached.name} (${duration}ms)`, LogLevel.DEBUG);
 		return cached;
 	}
 
-	const baseFileName = getDisplayName(normalizedBaseUri);
-	logWithTimestamp(`Member resolve CACHE MISS: ${file}/${member} (baseUri=${baseFileName})`, LogLevel.DEBUG);
+	logWithTimestamp(`Member resolve CACHE MISS: ${file}/${member}`, LogLevel.DEBUG);
 
 	try {
 		const resolvedMember = await queue.add(() => {return connection.sendRequest("memberResolve", [member, file])}) as IBMiMember|undefined;
@@ -179,8 +177,8 @@ export async function memberResolve(baseUri: string, member: string, file: strin
 		if (resolvedMember) {
 			logWithTimestamp(`Member resolve SUCCESS: ${file}/${member} -> ${resolvedMember.library}/${resolvedMember.file}/${resolvedMember.name} (${duration}ms)`, LogLevel.DEBUG);
 
-			if (!resolvedMembers[normalizedBaseUri]) resolvedMembers[normalizedBaseUri] = {};
-			resolvedMembers[normalizedBaseUri][fileKey] = resolvedMember;
+			// Store in global cache
+			resolvedMembers[fileKey] = resolvedMember;
 		} else {
 			logWithTimestamp(`Member resolve NOT FOUND: ${file}/${member} (${duration}ms)`, LogLevel.WARN);
 		}
@@ -197,22 +195,18 @@ export async function memberResolve(baseUri: string, member: string, file: strin
 }
 
 export async function streamfileResolve(baseUri: string, base: string[]): Promise<string|undefined> {
-	// Normalize baseUri by removing query parameters to ensure consistent cache keys
-	const normalizedBaseUri = baseUri.split('?')[0];
 	const baseString = base.join(`-`);
 	const startTime = Date.now();
 
-	// Check cache
-	if (resolvedStreamfiles[normalizedBaseUri] && resolvedStreamfiles[normalizedBaseUri][baseString]) {
-		const cached = resolvedStreamfiles[normalizedBaseUri][baseString];
+	// Check global cache
+	if (resolvedStreamfiles[baseString]) {
+		const cached = resolvedStreamfiles[baseString];
 		const duration = Date.now() - startTime;
-		const requestingFile = getDisplayName(normalizedBaseUri);
-		logWithTimestamp(`Streamfile resolve CACHE HIT: ${base[0]} (requesting: ${requestingFile}) -> ${cached} (${duration}ms)`, LogLevel.DEBUG);
+		logWithTimestamp(`Streamfile resolve CACHE HIT: ${base[0]} -> ${cached} (${duration}ms)`, LogLevel.DEBUG);
 		return cached;
 	}
 
-	const requestingFile = getDisplayName(normalizedBaseUri);
-	logWithTimestamp(`Streamfile resolve CACHE MISS: ${base[0]} (requesting: ${requestingFile})`, LogLevel.DEBUG);
+	logWithTimestamp(`Streamfile resolve CACHE MISS: ${base[0]}`, LogLevel.DEBUG);
 
 	const workspace = await getWorkspaceFolder(baseUri);
 
@@ -223,18 +217,18 @@ export async function streamfileResolve(baseUri: string, base: string[]): Promis
 		const duration = Date.now() - startTime;
 
 		if (resolvedPath) {
-			logWithTimestamp(`Streamfile resolve SUCCESS: ${base[0]} (requesting: ${requestingFile}) -> ${resolvedPath} (${duration}ms)`, LogLevel.DEBUG);
+			logWithTimestamp(`Streamfile resolve SUCCESS: ${base[0]} -> ${resolvedPath} (${duration}ms)`, LogLevel.DEBUG);
 
-			if (!resolvedStreamfiles[normalizedBaseUri]) resolvedStreamfiles[normalizedBaseUri] = {};
-			resolvedStreamfiles[normalizedBaseUri][baseString] = resolvedPath;
+			// Store in global cache
+			resolvedStreamfiles[baseString] = resolvedPath;
 		} else {
-			logWithTimestamp(`Streamfile resolve NOT FOUND: ${base[0]} (requesting: ${requestingFile}) (${duration}ms)`, LogLevel.WARN);
+			logWithTimestamp(`Streamfile resolve NOT FOUND: ${base[0]} (${duration}ms)`, LogLevel.WARN);
 		}
 
 		return resolvedPath;
 	} catch (e) {
 		const duration = Date.now() - startTime;
-		logWithTimestamp(`Streamfile resolve ERROR: ${base[0]} (requesting: ${requestingFile}) (${duration}ms)`, LogLevel.ERROR);
+		logWithTimestamp(`Streamfile resolve ERROR: ${base[0]} (${duration}ms)`, LogLevel.ERROR);
 		console.log(JSON.stringify({baseUri, base, paths}));
 		console.log(e);
 	}

--- a/extension/server/src/providers/linter/index.ts
+++ b/extension/server/src/providers/linter/index.ts
@@ -9,7 +9,7 @@ import Cache from '../../../../../language/models/cache';
 import documentFormattingProvider from './documentFormatting';
 
 import * as Project from "../project";
-import { connection, getFileRequest, getWorkingDirectory, resolvedMembers, resolvedStreamfiles, validateUri, watchedFilesChangeEvent } from '../../connection';
+import { connection, getDisplayName, getFileRequest, getWorkingDirectory, resolvedMembers, resolvedStreamfiles, validateUri, watchedFilesChangeEvent } from '../../connection';
 import { parseMemberUri } from '../../data';
 
 export let jsonCache: { [uri: string]: string } = {};

--- a/extension/server/src/providers/linter/index.ts
+++ b/extension/server/src/providers/linter/index.ts
@@ -9,7 +9,7 @@ import Cache from '../../../../../language/models/cache';
 import documentFormattingProvider from './documentFormatting';
 
 import * as Project from "../project";
-import { connection, getDisplayName, getFileRequest, getWorkingDirectory, resolvedMembers, resolvedStreamfiles, validateUri, watchedFilesChangeEvent } from '../../connection';
+import { connection, getDisplayName, getFileRequest, getWorkingDirectory, validateUri, watchedFilesChangeEvent } from '../../connection';
 import { parseMemberUri } from '../../data';
 
 export let jsonCache: { [uri: string]: string } = {};
@@ -77,10 +77,10 @@ export function initialise(connection: _Connection) {
 		}
 	})
 
-	documents.onDidClose(async e => {
-		const uriString = e.document.uri;
-		resolvedMembers[uriString] = {};
-		resolvedStreamfiles[uriString] = {};
+	documents.onDidClose(async () => {
+		// Note: We no longer clear resolvedMembers/resolvedStreamfiles here
+		// since they are now global caches that should persist across file closes.
+		// They will be cleared when the connection is reset or library list changes.
 	})
 }
 

--- a/extension/server/src/server.ts
+++ b/extension/server/src/server.ts
@@ -367,7 +367,9 @@ documents.onDidChangeContent(handler => {
 	// Clear any existing timer
 	if (state.timer) {
 		clearTimeout(state.timer);
-		logWithTimestamp(`Parse timer reset: ${fileName} (parseId: ${state.parseId + 1})`);
+		logWithTimestamp(`Debounce: Timer reset for ${fileName} (parseId: ${state.parseId + 1})`);
+	} else {
+		logWithTimestamp(`Debounce: Timer started for ${fileName} (300ms)`);
 	}
 
 	// Increment parse ID to invalidate any in-flight parses
@@ -377,6 +379,7 @@ documents.onDidChangeContent(handler => {
 	// Set a new timer to parse after a short delay
 	state.timer = setTimeout(() => {
 		delete state.timer;
+		logWithTimestamp(`Debounce: Timer expired for ${fileName}, starting parse (parseId: ${currentParseId})`);
 
 		// Always start a new parse - don't wait for old ones to finish
 		// Old parses will be invalidated by the parseId check

--- a/extension/server/src/server.ts
+++ b/extension/server/src/server.ts
@@ -21,7 +21,6 @@ import { connection, filesBeingFetchedForIncludes, getDisplayName, getFileReques
 import * as Linter from './providers/linter';
 import { referenceProvider } from './providers/reference';
 import Declaration from '../../../language/models/declaration';
-import { getPrettyType } from '../../../language/models/fixed';
 
 import * as Project from './providers/project';
 import workspaceSymbolProvider from './providers/project/workspaceSymbol';
@@ -316,13 +315,6 @@ parser.setIncludeFileFetch(async (stringUri: string, includeString: string) => {
 			uri: validUri
 		};
 	}
-
-	fetchingInProgress[includeString] = false;
-
-	return {
-		found: false,
-		uri: validUri
-	};
 });
 
 if (languageToolsEnabled) {

--- a/extension/server/src/server.ts
+++ b/extension/server/src/server.ts
@@ -17,7 +17,7 @@ import { URI } from 'vscode-uri';
 import completionItemProvider from './providers/completionItem';
 import hoverProvider from './providers/hover';
 
-import { connection, filesBeingFetchedForIncludes, getFileRequest, getObject as getObjectData, handleClientRequests, initializeLogLevel, LogLevel, memberResolve, streamfileResolve, validateUri, logWithTimestamp } from "./connection";
+import { connection, filesBeingFetchedForIncludes, getDisplayName, getFileRequest, getObject as getObjectData, handleClientRequests, initializeLogLevel, LogLevel, memberResolve, streamfileResolve, validateUri, logWithTimestamp } from "./connection";
 import * as Linter from './providers/linter';
 import { referenceProvider } from './providers/reference';
 import Declaration from '../../../language/models/declaration';
@@ -144,7 +144,7 @@ parser.setIncludeFileFetch(async (stringUri: string, includeString: string) => {
 	const currentUri = URI.parse(stringUri);
 	const uriPath = currentUri.path;
 	// Extract clean filename without query parameters
-	const parentFileName = (uriPath.split('/').pop() || stringUri).split('?')[0];
+	const parentFileName = getDisplayName(stringUri);
 	const fetchStartTime = Date.now();
 
 	let cleanString: string | undefined;
@@ -291,7 +291,7 @@ parser.setIncludeFileFetch(async (stringUri: string, includeString: string) => {
 			const validSource = await getFileRequest(validUri, true); // true = skip debounce for include files
 			if (validSource) {
 				const duration = Date.now() - fetchStartTime;
-				const fileName = validUri.split('/').pop() || validUri;
+				const fileName = getDisplayName(validUri);
 				logWithTimestamp(`Include fetch completed: ${includeString} -> ${fileName} (${duration}ms, found)`, LogLevel.INFO);
 				fetchingInProgress[includeString] = false;
 				return {
@@ -350,7 +350,7 @@ const documentParseState: {
 
 // Execute a parse for a document
 function executeParse(uri: string, parseId: number, document: any) {
-	const fileName = (uri.split('/').pop() || uri).split('?')[0];
+	const fileName = getDisplayName(uri);
 	const state = documentParseState[uri];
 
 	if (!state) return;
@@ -414,7 +414,7 @@ function executeParse(uri: string, parseId: number, document: any) {
 documents.onDidChangeContent(handler => {
 	const uri = handler.document.uri;
 	// Extract clean filename without query parameters
-	const fileName = (uri.split('/').pop() || uri).split('?')[0];
+	const fileName = getDisplayName(uri);
 
 	// Initialize state if needed
 	if (!documentParseState[uri]) {

--- a/language/parser.ts
+++ b/language/parser.ts
@@ -775,9 +775,13 @@ export default class Parser {
               case `/INCLUDE`:
                 if (options.withIncludes && this.includeFileFetch && lineCanRun()) {
                   const includePath = Parser.getIncludeFromDirective(line);
-          
+
                   if (includePath) {
-                    const include = await this.includeFileFetch(workingUri, includePath);
+                    // Use fileUri (current file) instead of workingUri (root document) to ensure:
+                    // 1. Correct parent file is logged for nested includes
+                    // 2. Member/streamfile resolution caches are scoped per requesting file
+                    // 3. Workspace context resolution uses the actual requesting file
+                    const include = await this.includeFileFetch(fileUri, includePath);
                     if (include.found && include.uri) {
                       if (!scopes[0].includes.some(inc => inc.toPath === include.uri)) {
                         scopes[0].includes.push({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-rpgle",
-	"version": "0.31.1",
+	"version": "0.33.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-rpgle",
-			"version": "0.31.1",
+			"version": "0.33.2",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,19 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Whether to show the fixed-format ruler by default."
+				},
+				"vscode-rpgle.logLevel": {
+					"type": "string",
+					"default": "info",
+					"enum": ["none", "error", "warn", "info", "debug"],
+					"enumDescriptions": [
+						"No logging",
+						"Only errors",
+						"Errors and warnings",
+						"Errors, warnings, and info (default)",
+						"All messages including debug output"
+					],
+					"description": "Controls the verbosity of RPGLE language server logging output."
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/halcyon-tech/vscode-rpgle"
 	},
 	"license": "MIT",
-	"version": "0.33.4-dev.0",
+	"version": "0.33.4-dev.0.rm-0006",
 	"engines": {
 		"vscode": "^1.70.0"
 	},

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/halcyon-tech/vscode-rpgle"
 	},
 	"license": "MIT",
-	"version": "0.33.4-dev.0.rm-0006",
+	"version": "0.33.4-dev.0",
 	"engines": {
 		"vscode": "^1.70.0"
 	},

--- a/tests/suite/directives.test.ts
+++ b/tests/suite/directives.test.ts
@@ -725,3 +725,72 @@ test('/IF DEFINED with Not - mixed case', async () => {
   expect(cache.variables.length).toBe(1);
   expect(cache.variables[0].name).toBe('Var2');
 });
+
+test('rapid re-parse produces consistent offsets', async () => {
+  const base = [
+    `**FREE`,
+    `Dcl-S MyVar Char(10);`,
+  ].join(`\n`);
+
+  const versions = [
+    base + `\nMyVar = 'hello';`,
+    base + `\nMyVar = 'hello';\nDcl-S MyVar2 Char(20);`,
+    base + `\nMyVar = 'hello';\nDcl-S MyVar2 Char(20);\nMyVar2 = 'world';`,
+  ];
+
+  for (const content of versions) {
+    const cache = await parser.getDocs(uri, content, { ignoreCache: true, withIncludes: true });
+    const myVarDefs = cache.variables.filter(v => v.name.toUpperCase() === 'MYVAR');
+    expect(myVarDefs.length).toBe(1);
+    expect(myVarDefs[0].position.range.line).toBe(1);
+  }
+});
+
+test('re-parse with includes does not duplicate definitions', async () => {
+  const lines = [
+    `**FREE`,
+    `Ctl-Opt DftActGrp(*No);`,
+    `/copy './rpgle/depth1.rpgleinc'`,
+    `Dcl-S MyCustomerName1 char(5);`,
+    `Return;`
+  ].join(`\n`);
+
+  // Parse the same content twice with ignoreCache
+  await parser.getDocs(uri, lines, { withIncludes: true, ignoreCache: true });
+  const cache = await parser.getDocs(uri, lines, { withIncludes: true, ignoreCache: true });
+
+  // Should have exactly 2 includes (depth1 -> copy3), not duplicates
+  expect(cache.includes.length).toBe(2);
+
+  // Each variable should appear exactly once
+  const varNames = cache.variables.map(v => v.name.toUpperCase());
+  const uniqueVarNames = [...new Set(varNames)];
+  expect(varNames.length).toBe(uniqueVarNames.length);
+});
+
+test('editing around include directives maintains offsets', async () => {
+  const lines1 = [
+    `**FREE`,
+    `/copy './rpgle/copy4.rpgleinc'`,
+    `Dcl-S LocalVar Char(10);`,
+    `Return;`
+  ].join(`\n`);
+
+  const cache1 = await parser.getDocs(uri, lines1, { withIncludes: true, ignoreCache: true });
+  const localVarLine1 = cache1.variables.find(v => v.name.toUpperCase() === 'LOCALVAR')?.position.range.line;
+
+  // Add a new include line before LocalVar
+  const lines2 = [
+    `**FREE`,
+    `/copy './rpgle/copy4.rpgleinc'`,
+    `/copy './rpgle/file1.rpgleinc'`,
+    `Dcl-S LocalVar Char(10);`,
+    `Return;`
+  ].join(`\n`);
+
+  const cache2 = await parser.getDocs(uri, lines2, { withIncludes: true, ignoreCache: true });
+  const localVarLine2 = cache2.variables.find(v => v.name.toUpperCase() === 'LOCALVAR')?.position.range.line;
+
+  // LocalVar should shift down by 1 line
+  expect(localVarLine2).toBe(localVarLine1! + 1);
+});


### PR DESCRIPTION
### The Problem

I've experienced odd behaviour when changing RPG source in that the linter would suddenly display a "Variable name casing does not match definition" warning at various points within the source I was editing. Although this appears to be a linter issue it goes further, the tokens appear to lose their offset within the source so when you use something like F2 to rename a symbol it loses track of where those symbols are and renames the wrong text in the source.

* I notice the problem most often when adding additional `/include` files - I do use a lot of `/include` files.
* I've not noticed it whilst editing local source only remote source.

I was able to pull together a very simple example that replicates the problem, which I've also created a video that demonstrates the problem as it's not easy to understand from the description.

https://github.com/user-attachments/assets/54cc2531-9ee7-46fd-8c5d-132294936dd1

Full disclosure I leaned on Claude Code to help fix the problem and produce the documentation of the changes.


The extension was experiencing race condition offset issues that manifested as false linter errors during live editing:
1. Immediate parsing on every keystroke - The parser was invoked synchronously on every document change
1. Multiple concurrent parse operations - When users typed quickly, multiple parse operations would run simultaneously on different document versions
1. Stale/incorrect offsets - This resulted in duplicate definitions with incorrect line/column offsets in the parser cache
1. Duplicate include file fetches - The same include file could be fetched multiple times during a single parse operation
1. False linter diagnostics - The linter would report incorrect errors (e.g., variable name casing issues) based on stale offset data
1. Poor user experience - Diagnostics would flicker, show false warnings, and create confusion during normal editing


### The Solution

The fix implements a comprehensive debouncing and synchronization mechanism with multiple layers of protection:

1. Debouncing (server.ts)
    * Added a 300ms debounce timer to delay parsing until the user pauses typing
    * Each new keystroke clears the previous timer and restarts the countdown
    * This prevents triggering expensive parse operations on every character typed
    * **Include files and first-open documents bypass the debounce**  so include resolution is not artificially delayed

2. Parse State Tracking
```ts
const documentParseState: {
  [uri: string]: {
    timer?: NodeJS.Timeout,      // The debounce timer
    parseId: number,             // Incrementing counter for each change
    parseStartTime?: number,     // Timestamp for duration tracking
    isParsing: boolean,          // Whether a parse is currently active
    needsReparse: boolean        // Whether a re-parse is queued
  }
} = {};
```

3. Parse ID Validation
    * Each document change increments a parseId counter
    * Parse operations capture the current parseId before starting
    * Diagnostics are only updated if the parseId still matches when the parse completes
    * This invalidates any slow/stale parse operations that finish after newer changes have been made
  
4. Concurrent Parse Handling
    * Only **one parse at a time** is allowed per document
    * If a new change arrives while a parse is active, it sets `needsReparse = true` rather than starting a second     concurrent parse
    * When the active parse completes, it checks `needsReparse` and triggers the queued re-parse automatically
    * Combined with parseId validation, this ensures stale results are never applied to diagnostics

5. Include File Fetch Deduplication (server.ts)

Fixed critical bug where fetchingInProgress flag was cleared too early:

```ts
// BEFORE (buggy):
fetchingInProgress[includeString] = false;  // Cleared here
if (validUri) {
  const validSource = await getFileRequest(validUri);  // But async work continues!
  ...
}

// AFTER (fixed):
if (validUri) {
  const validSource = await getFileRequest(validUri);
  if (validSource) {
    fetchingInProgress[includeString] = false;  // Cleared AFTER async work
    return { found: true, ... };
  }
}
fetchingInProgress[includeString] = false;  // Or here if not found
```

This prevents duplicate server requests for the same include file during a single parse operation.

6. Fixed Nested Include Parent URI (parser.ts)

Changed the include file fetch call to pass `fileUri` (the current file being parsed) instead of `workingUri` (the root document). This fixes:

* Incorrect parent file being logged for nested includes
* Workspace context resolution using the wrong requesting file

7. Flattened Resolution Caches (connection.ts, linter/index.ts)

Changed `resolvedMembers` and `resolvedStreamfiles` from per-document maps (`{[baseUri]: {[fileKey]: ...}}`) to global flat maps (`{[fileKey]: ...}`):

* Member and streamfile resolution results are connection-level (based on library list), not document-specific
* Closing a document no longer clears the cache, so re-opening a file benefits from previous resolutions
* The `onDidClose` handler in the linter no longer purges these caches

8. Configurable Log Level Setting (package.json, connection.ts)

Added a new `vscode-rpgle.logLevel` setting with options: `none`, `error`, `warn`, `info` (default), `debug`.

* All logging uses `logWithTimestamp()` which respects the configured level
* Log level is read from workspace configuration on server initialization
* Clean filename display via `getDisplayName()` strips query parameters and decodes URL encoding

9. Enhanced Logging (server.ts, connection.ts)

Added comprehensive timestamped logging for debugging:

* Parse lifecycle tracking (start, completion, duration, parseId, stale detection)
* Include file fetch operations with timing and cache status
* URI validation with local cache hits vs server requests
* File fetch operations showing cache hits vs server fetches with byte counts
* Clean filename extraction (strips query parameters for readability)

10. Error Handling (lines 398-402)

* Added `.catch()` block to gracefully handle parse errors
* Logs errors with timing information
* Ensures proper cleanup even on parse failure


### Technical Flow
1. User types → Document change event fires
1. Clear old timer → Cancel any pending parse operation
1. Increment `parseId` → Invalidate any in-flight parses
1. Start new timer (300ms for edits, 0ms for first open/includes)
1. Timer fires → Check if a parse is already active
1. If active → Set `needsReparse = true` and wait
1. If idle → Start new parse operation with include fetches
1. Include fetch deduplication → Prevent duplicate server requests
1. Parse completes → Validate `parseId` → Only update diagnostics if still latest
1. Check `needsReparse` → Trigger queued re-parse if needed


### Key Improvements
1. **Parse ID validation** prevents stale results from updating diagnostics
1. **Single active parse with re-parse queuing** ensures consistency without blocking responsiveness
1. **Include file debounce bypass** ensures include resolution is not artificially delayed
1. **Include fetch deduplication** eliminates redundant server requests
1. **Fixed nested include parent URI** ensures correct file context for include resolution
1. **Flattened resolution caches** persist across file open/close cycles for better performance
1. **Configurable log level** gives users control over logging verbosity
1. **Enhanced logging** provides visibility into parse operations and performance
1. **Better error handling** ensures state consistency

### Files Changed

* `extension/server/src/server.ts` - Debouncing, parse state tracking, concurrent parse handling, include fetch deduplication, logging
* `extension/server/src/connection.ts` - Logging infrastructure, configurable log level, flattened resolution caches, enhanced logging for URI validation, file fetches, and member/streamfile resolution
* `extension/server/src/providers/linter/index.ts` - Removed per-document cache clearing on close (caches are now global)
* `language/parser.ts` - Fixed include file fetch to use current file URI instead of root document URI
* `package.json` - Added `vscode-rpgle.logLevel` configuration setting


### Observations

I noticed the following whilst working on this fix.

* The `/include` files are loaded a lot, the extension seems to reload the same file many, many times. I connect over VPN for a lot of my clients and loading source can take a while.
    * URI validation cache relies on VS Code's TextDocuments collection, which evicts (garbage collects) include files after ~5 minutes when they're not open in a tab.
* File declarations don't always load the results in the outline view.
* There doesn't appear to be a way to reload the content of the `/include` files, if they've changed.
* There is no feedback on whether the current source is still being parsed.
* There is an option in the Outline view to reload cache though this only appears to reload file declarations, maybe this should reload all `/includes` too.
* How often is the outline view updated? It doesn't always appear to be up to date with recent source changes.
* `RPGLINT.JSON` is not cached in TextDocuments collection, causing a server round-trip every time it's needed.
* If you open a file to browse some code and then quickly close the file the parsing continues in the background.



### Checklist

* [X] have tested my change
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [X] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement