### PR TITLE
Fix duplicate include loading in shared include graphs (issue #503)

### DIFF
--- a/language/ile/parser.ts
+++ b/language/ile/parser.ts
@@ -291,15 +291,21 @@ export default class Parser {
       const cleanBase = baseFileUri.split(`?`)[0];
       const slashIndex = Math.max(cleanBase.lastIndexOf(`/`), cleanBase.lastIndexOf(`\\`));
       const baseDir = slashIndex >= 0 ? cleanBase.substring(0, slashIndex) : cleanBase;
-      return `${baseDir}::${includePath.toLowerCase()}`;
+      const includeLiteral = includePath.trim().replace(/^['"]|['"]$/g, ``);
+      return `${baseDir}::${includeLiteral}`;
     };
 
     const fetchIncludeOnce = async (baseFileUri: string, includePath: string): Promise<IncludeFetchResult> => {
+      const includeFetcher = this.includeFileFetch;
+      if (!includeFetcher) {
+        return {found: false};
+      }
+
       const key = getIncludeFetchKey(baseFileUri, includePath);
       let inFlight = includeFetchCache.get(key);
 
       if (!inFlight) {
-        inFlight = this.includeFileFetch(baseFileUri, includePath);
+        inFlight = includeFetcher(baseFileUri, includePath);
         includeFetchCache.set(key, inFlight);
       }
 

--- a/language/ile/parser.ts
+++ b/language/ile/parser.ts
@@ -17,6 +17,7 @@ export type tablePromise = (name: string, aliases?: boolean) => Promise<Declarat
 export type includeFilePromise = (baseFile: string, includeString: string) => Promise<{found: boolean, uri?: string, content?: string}>;
 export type TableDetail = {[name: string]: {fetched: number, fetching?: boolean, recordFormats: Declaration[]}};
 export interface ParseOptions {withIncludes?: boolean, ignoreCache?: boolean, collectReferences?: boolean};
+type IncludeFetchResult = {found: boolean, uri?: string, content?: string};
 
 const PROGRAMPARMS_NAME = `PROGRAMPARMS`;
 
@@ -281,6 +282,29 @@ export default class Parser {
     let currentGroup: "structs"|"procedures"|"constants"|"parameters";
 
     let definedMacros: string[] = [];
+
+    // Deduplicate include loads within this parse pass.
+    // Key is based on parent directory context + include literal so repeated
+    // include graph paths (a -> b,c -> d) do not trigger duplicate fetches.
+    const includeFetchCache = new Map<string, Promise<IncludeFetchResult>>();
+    const getIncludeFetchKey = (baseFileUri: string, includePath: string): string => {
+      const cleanBase = baseFileUri.split(`?`)[0];
+      const slashIndex = Math.max(cleanBase.lastIndexOf(`/`), cleanBase.lastIndexOf(`\\`));
+      const baseDir = slashIndex >= 0 ? cleanBase.substring(0, slashIndex) : cleanBase;
+      return `${baseDir}::${includePath.toLowerCase()}`;
+    };
+
+    const fetchIncludeOnce = async (baseFileUri: string, includePath: string): Promise<IncludeFetchResult> => {
+      const key = getIncludeFetchKey(baseFileUri, includePath);
+      let inFlight = includeFetchCache.get(key);
+
+      if (!inFlight) {
+        inFlight = this.includeFileFetch(baseFileUri, includePath);
+        includeFetchCache.set(key, inFlight);
+      }
+
+      return inFlight;
+    };
 
     /**
      * Parse the tokens and add references to the definitions
@@ -792,7 +816,7 @@ export default class Parser {
                     // 1. Correct parent file is logged for nested includes
                     // 2. Member/streamfile resolution caches are scoped per requesting file
                     // 3. Workspace context resolution uses the actual requesting file
-                    const include = await this.includeFileFetch(fileUri, includePath);
+                    const include = await fetchIncludeOnce(fileUri, includePath);
                     if (include.found && include.uri && include.content !== undefined) {
                       if (!scopes[0].includes.some(inc => inc.toPath === include.uri)) {
                         scopes[0].includes.push({

--- a/language/ile/parser.ts
+++ b/language/ile/parser.ts
@@ -10,22 +10,20 @@ import { parseFLine, parseCLine, parsePLine, parseDLine, getPrettyType, prettyTy
 import { Token } from "./types";
 import { Keywords } from "./parserTypes";
 import { NO_NAME } from "./statement";
+import type { tablePromise, includeFilePromise, IncludeFetchResult } from "../parserFactory";
 
 const HALF_HOUR = (30 * 60 * 1000);
 
-export type tablePromise = (name: string, aliases?: boolean) => Promise<Declaration[]>;
-export type includeFilePromise = (baseFile: string, includeString: string) => Promise<{found: boolean, uri?: string, content?: string}>;
-export type TableDetail = {[name: string]: {fetched: number, fetching?: boolean, recordFormats: Declaration[]}};
-export interface ParseOptions {withIncludes?: boolean, ignoreCache?: boolean, collectReferences?: boolean};
-type IncludeFetchResult = {found: boolean, uri?: string, content?: string};
+export type TableDetail = { [name: string]: { fetched: number, fetching?: boolean, recordFormats: Declaration[] } };
+export interface ParseOptions { withIncludes?: boolean, ignoreCache?: boolean, collectReferences?: boolean };
 
 const PROGRAMPARMS_NAME = `PROGRAMPARMS`;
 
 export default class Parser {
-  parsedCache: {[thePath: string]: Cache | undefined} = {};
+  parsedCache: { [thePath: string]: Cache | undefined } = {};
   tables: TableDetail = {};
-  tableFetch: tablePromise|undefined;
-  includeFileFetch: includeFilePromise|undefined;
+  tableFetch: tablePromise | undefined;
+  includeFileFetch: includeFilePromise | undefined;
 
   constructor() {
   }
@@ -104,10 +102,10 @@ export default class Parser {
   }
 
   /**
-	 * @param {string} line
-	 * @returns {string|undefined}
-	 */
-  static getIncludeFromDirective(line: string): string|undefined {
+   * @param {string} line
+   * @returns {string|undefined}
+   */
+  static getIncludeFromDirective(line: string): string | undefined {
     if (line.indexOf(`*`) !== line.toLowerCase().indexOf(`*libl`)) return; // Likely comment
     if (line.trim().startsWith(`//`)) return; // Likely comment
 
@@ -126,13 +124,13 @@ export default class Parser {
       directiveLength = 9
     };
 
-    let directiveValue: string|undefined;
+    let directiveValue: string | undefined;
 
     if (directivePosition >= 0) {
       if (comment >= 0) {
-        directiveValue = line.substring(directivePosition+directiveLength, comment).trim();
+        directiveValue = line.substring(directivePosition + directiveLength, comment).trim();
       } else {
-        directiveValue = line.substring(directivePosition+directiveLength).trim();
+        directiveValue = line.substring(directivePosition + directiveLength).trim();
       }
     }
 
@@ -165,9 +163,9 @@ export default class Parser {
     return tokens;
   }
 
-  static fromBlocksGetTokens(tokensWithBlocks: Token[], cursorIndex: number): {preToken?: Token, block: Token[]} {
-    let insideBlockIndex: number|undefined;
-    let preToken: Token|undefined;
+  static fromBlocksGetTokens(tokensWithBlocks: Token[], cursorIndex: number): { preToken?: Token, block: Token[] } {
+    let insideBlockIndex: number | undefined;
+    let preToken: Token | undefined;
     let insideBlock: Token | undefined;
 
     while ((insideBlockIndex = tokensWithBlocks.findIndex(t => t.type === `block` && t.block && t.range.start <= cursorIndex && t.range.end >= cursorIndex)) !== -1) {
@@ -205,7 +203,7 @@ export default class Parser {
     return lastToken;
   }
 
-  async getDocs(workingUri: string, baseContent?: string, options: ParseOptions = {withIncludes: true, collectReferences: true}): Promise<Cache|undefined> {
+  async getDocs(workingUri: string, baseContent?: string, options: ParseOptions = { withIncludes: true, collectReferences: true }): Promise<Cache | undefined> {
     const existingCache = this.getParsedCache(workingUri);
     if (options.ignoreCache !== true && existingCache) {
       return existingCache;
@@ -234,7 +232,7 @@ export default class Parser {
         }
       }
 
-      if(objectName === `*EXTDESC`){
+      if (objectName === `*EXTDESC`) {
         // Check for external object
         const extDesc = keywords['EXTDESC'];
         if (extDesc && typeof extDesc === `string`) {
@@ -254,7 +252,7 @@ export default class Parser {
     // In fixed format, symbol names can be spread over multiple lines
     // and we use tokens to collect each part of the name.
     // ========
-    let potentialName: Token[]|undefined;
+    let potentialName: Token[] | undefined;
     const pushPotentialNameToken = (token?: Token) => {
       if (!potentialName) {
         potentialName = [];
@@ -263,7 +261,7 @@ export default class Parser {
         potentialName.push(token);
       }
     }
-    const getPotentialNameToken = (): Token|undefined => {
+    const getPotentialNameToken = (): Token | undefined => {
       if (potentialName && potentialName.length > 0) {
         return {
           type: `block`,
@@ -279,7 +277,7 @@ export default class Parser {
       }
     }
 
-    let currentGroup: "structs"|"procedures"|"constants"|"parameters";
+    let currentGroup: "structs" | "procedures" | "constants" | "parameters";
 
     let definedMacros: string[] = [];
 
@@ -298,7 +296,7 @@ export default class Parser {
     const fetchIncludeOnce = async (baseFileUri: string, includePath: string): Promise<IncludeFetchResult> => {
       const includeFetcher = this.includeFileFetch;
       if (!includeFetcher) {
-        return {found: false};
+        return { found: false };
       }
 
       const key = getIncludeFetchKey(baseFileUri, includePath);
@@ -352,7 +350,7 @@ export default class Parser {
         if (!part.value) continue;
         const lookupName = (isSpecial ? part.value.substring(1) : part.value).toUpperCase();
 
-        let defRef: Declaration|undefined;
+        let defRef: Declaration | undefined;
 
         if (isSpecial) {
           // The only specials that can be looked up at global indicators
@@ -432,7 +430,7 @@ export default class Parser {
       const EOL = allContent.includes(`\r\n`) ? `\r\n` : `\n`;
       let lines = allContent.split(EOL);
 
-      let postProcessingStatements: {[procedure: string]: (Token | undefined)[][]} = {'GLOBAL': []};
+      let postProcessingStatements: { [procedure: string]: (Token | undefined)[][] } = { 'GLOBAL': [] };
 
       const addPostProcessingStatements = (procedure = `GLOBAL`, statement: (Token | undefined)[]) => {
         if (!options.collectReferences) return;
@@ -457,11 +455,11 @@ export default class Parser {
       if (lines.length === 0) return;
 
       let currentTitle = undefined, currentDescription = [];
-      let currentTags: {tag: string, content: string}[] = [];
+      let currentTags: { tag: string, content: string }[] = [];
 
-      let currentItem: Declaration|undefined;
-      let currentSub: Declaration|undefined;
-      let currentProcName: string|undefined;
+      let currentItem: Declaration | undefined;
+      let currentSub: Declaration | undefined;
+      let currentProcName: string | undefined;
 
       let resetDefinition = false; //Set to true when you're done defining a new item
       let docs = false; // If section is for ILEDocs
@@ -472,11 +470,11 @@ export default class Parser {
       let lineIsFree = false;
 
       /** Used for handling multiline statements */
-      let currentStmtStart: {content?: string, line: number, index: number}|undefined;
+      let currentStmtStart: { content?: string, line: number, index: number } | undefined;
       /** True when the previous continuation line ended with `...` (direct concat, trim next line) */
       let dotsConcat = false;
 
-      let directIfScope: {condition: boolean}[] = [];
+      let directIfScope: { condition: boolean }[] = [];
 
       let lineCanRun = () => {
         return directIfScope.length === 0 || directIfScope.every(scope => scope.condition);
@@ -491,10 +489,10 @@ export default class Parser {
         for (let i = inputLine.length - 1; i >= 0; i--) {
           switch (inputLine[i]) {
             case '/':
-              if (inputLine[i-1] === `/`) {
+              if (inputLine[i - 1] === `/`) {
                 // It's a comment!
                 inString = false;
-                comment = i-1;
+                comment = i - 1;
                 i--;
 
                 return inputLine.substring(0, comment).trimEnd();
@@ -505,7 +503,7 @@ export default class Parser {
               break;
             case ';':
               if (!inString) {
-                return inputLine.substring(0, i+1).trimEnd();
+                return inputLine.substring(0, i + 1).trimEnd();
               }
               break;
           }
@@ -553,7 +551,7 @@ export default class Parser {
           if (recordFormats.length > 0) {
             // Got to fix the positions for the defintions to be the declare.
             recordFormats.forEach(recordFormat => {
-              recordFormat.keyword = {[objectName]: true};
+              recordFormat.keyword = { [objectName]: true };
 
               recordFormat.position = currentItem.position;
 
@@ -567,7 +565,7 @@ export default class Parser {
           }
         }
 
-        let renames: {[recordFormatFrom: string]: string} = {};
+        let renames: { [recordFormatFrom: string]: string } = {};
         if (fOptions.keyword[`RENAME`] && typeof fOptions.keyword[`RENAME`] === `string`) {
           const renameParts = fOptions.keyword[`RENAME`].split(`:`);
           if (renameParts.length === 2) {
@@ -674,13 +672,13 @@ export default class Parser {
 
       for (let li = 0; li < lines.length; li++) {
         if (li >= 1) {
-          lineIndex += lines[li-1].length + EOL.length;
+          lineIndex += lines[li - 1].length + EOL.length;
         }
 
         const scope = scopes[scopes.length - 1];
 
         let baseLine = lines[li];
-        let spec: string|undefined;
+        let spec: string | undefined;
 
         lineIsFree = false;
         lineNumber += 1;
@@ -812,91 +810,91 @@ export default class Parser {
               return;
             } else {
               switch (parts[0]) {
-              case `/COPY`:
-              case `/INCLUDE`:
-                if (options.withIncludes && this.includeFileFetch && lineCanRun()) {
-                  const includePath = Parser.getIncludeFromDirective(line);
+                case `/COPY`:
+                case `/INCLUDE`:
+                  if (options.withIncludes && this.includeFileFetch && lineCanRun()) {
+                    const includePath = Parser.getIncludeFromDirective(line);
 
-                  if (includePath) {
-                    // Use fileUri (current file) instead of workingUri (root document) to ensure:
-                    // 1. Correct parent file is logged for nested includes
-                    // 2. Member/streamfile resolution caches are scoped per requesting file
-                    // 3. Workspace context resolution uses the actual requesting file
-                    const include = await fetchIncludeOnce(fileUri, includePath);
-                    if (include.found && include.uri && include.content !== undefined) {
-                      if (!scopes[0].includes.some(inc => inc.toPath === include.uri)) {
-                        scopes[0].includes.push({
-                          fromPath: fileUri,
-                          toPath: include.uri,
-                          line: lineNumber
-                        });
+                    if (includePath) {
+                      // Use fileUri (current file) instead of workingUri (root document) to ensure:
+                      // 1. Correct parent file is logged for nested includes
+                      // 2. Member/streamfile resolution caches are scoped per requesting file
+                      // 3. Workspace context resolution uses the actual requesting file
+                      const include = await fetchIncludeOnce(fileUri, includePath);
+                      if (include.found && include.uri && include.content !== undefined) {
+                        if (!scopes[0].includes.some(inc => inc.toPath === include.uri)) {
+                          scopes[0].includes.push({
+                            fromPath: fileUri,
+                            toPath: include.uri,
+                            line: lineNumber
+                          });
 
-                        try {
-                          await parseContent(include.uri, include.content);
-                        } catch (e) {
-                          console.log(`Error parsing include: ${include.uri}`);
-                          console.log(e);
+                          try {
+                            await parseContent(include.uri, include.content);
+                          } catch (e) {
+                            console.log(`Error parsing include: ${include.uri}`);
+                            console.log(e);
+                          }
                         }
                       }
                     }
                   }
-                }
-                continue;
-              case `/IF`:
-                // Not conditions can run
-                let condition = false;
-                let hasNot = (parts[1] === `NOT`);
-                let expr = tokens.slice(hasNot ? 2 : 1);
-                let keywords = Parser.expandKeywords(expr);
-
-                if (typeof keywords[`DEFINED`] === `string`) {
-                  // Keywords are not uppercased at this point, but defined macros are always uppercased, so we need to uppercase the keyword before checking.
-                  condition = definedMacros.includes(keywords[`DEFINED`].toUpperCase());
-                }
-
-                if (hasNot) condition = !condition;
-
-                directIfScope.push({condition: condition});
-                continue;
-              case `/ELSE`:
-                if (directIfScope.length > 0) {
-                  directIfScope[directIfScope.length - 1].condition = !directIfScope[directIfScope.length - 1].condition;
-                }
-                continue;
-              case `/ELSEIF`:
-                if (directIfScope.length > 0) {
-                  directIfScope.pop();
-                  directIfScope.push({condition: false});
-                }
-                continue;
-              case `/ENDIF`:
-                if (directIfScope.length > 0) {
-                  directIfScope.pop();
-                }
-                continue;
-
-              case `/DEFINE`:
-                if (lineCanRun()) {
-                  definedMacros.push(parts[1]);
-                }
-
-                continue;
-              default:
-                if (line.startsWith(`/`)) {
                   continue;
-                }
-                if (!lineCanRun()) {
-                  // Ignore lines inside the IF scope.
+                case `/IF`:
+                  // Not conditions can run
+                  let condition = false;
+                  let hasNot = (parts[1] === `NOT`);
+                  let expr = tokens.slice(hasNot ? 2 : 1);
+                  let keywords = Parser.expandKeywords(expr);
+
+                  if (typeof keywords[`DEFINED`] === `string`) {
+                    // Keywords are not uppercased at this point, but defined macros are always uppercased, so we need to uppercase the keyword before checking.
+                    condition = definedMacros.includes(keywords[`DEFINED`].toUpperCase());
+                  }
+
+                  if (hasNot) condition = !condition;
+
+                  directIfScope.push({ condition: condition });
                   continue;
-                }
-                break;
+                case `/ELSE`:
+                  if (directIfScope.length > 0) {
+                    directIfScope[directIfScope.length - 1].condition = !directIfScope[directIfScope.length - 1].condition;
+                  }
+                  continue;
+                case `/ELSEIF`:
+                  if (directIfScope.length > 0) {
+                    directIfScope.pop();
+                    directIfScope.push({ condition: false });
+                  }
+                  continue;
+                case `/ENDIF`:
+                  if (directIfScope.length > 0) {
+                    directIfScope.pop();
+                  }
+                  continue;
+
+                case `/DEFINE`:
+                  if (lineCanRun()) {
+                    definedMacros.push(parts[1]);
+                  }
+
+                  continue;
+                default:
+                  if (line.startsWith(`/`)) {
+                    continue;
+                  }
+                  if (!lineCanRun()) {
+                    // Ignore lines inside the IF scope.
+                    continue;
+                  }
+                  break;
               }
             }
           }
 
 
           if (!currentStmtStart || !currentStmtStart.content) {
-            currentStmtStart = {line: lineNumber, index: lineIndex};
+            currentStmtStart = { line: lineNumber, index: lineIndex };
           }
 
           if (lineIsComment) {
@@ -949,302 +947,312 @@ export default class Parser {
           }
 
           switch (parts[0]) {
-          case `CTL-OPT`:
-            globalKeyword.push(...parts.slice(1));
-            break;
+            case `CTL-OPT`:
+              globalKeyword.push(...parts.slice(1));
+              break;
 
-          case `DCL-F`:
-            if (currentItem === undefined) {
-              if (parts.length > 1) {
-                currentItem = new Declaration(`file`);
-                currentItem.name = partsLower[1];
-                currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
+            case `DCL-F`:
+              if (currentItem === undefined) {
+                if (parts.length > 1) {
+                  currentItem = new Declaration(`file`);
+                  currentItem.name = partsLower[1];
+                  currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
 
-                currentItem.position = {
-                  path: fileUri,
-                  range: tokens[1].range
-                };
+                  currentItem.position = {
+                    path: fileUri,
+                    range: tokens[1].range
+                  };
 
-                currentItem.range = {
-                  start: currentStmtStart.line,
-                  end: lineNumber
-                }
-
-                await handleFSpec(currentItem, {
-                  keyword: currentItem.keyword,
-                  unique: parts.length.toString()
-                });
-
-                scope.addSymbol(currentItem);
-                resetDefinition = true;
-              }
-            }
-            break;
-
-          case `DCL-C`:
-            if (currentItem === undefined) {
-              if (parts.length > 1) {
-                currentItem = new Declaration(`constant`);
-                currentItem.name = partsLower[1];
-                currentItem.keyword = Parser.expandKeywords(tokens.slice(2), true);
-
-                currentItem.position = {
-                  path: fileUri,
-                  range: tokens[1].range
-                };
-
-                currentItem.range = {
-                  start: currentStmtStart.line,
-                  end: lineNumber
-                };
-
-                scope.addSymbol(currentItem);
-                resetDefinition = true;
-              }
-            }
-            break;
-
-          case `DCL-S`:
-            if (parts.length > 1) {
-              currentItem = new Declaration(`variable`);
-              currentItem.name = partsLower[1];
-              currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
-              currentItem.tags = currentTags;
-
-              currentItem.position = {
-                path: fileUri,
-                range: tokens[1].range
-              };
-
-              currentItem.range = {
-                start: currentStmtStart.line,
-                end: lineNumber
-              };
-
-              scope.addSymbol(currentItem);
-              resetDefinition = true;
-            }
-            break;
-
-          case `DCL-ENUM`:
-            if (parts.length > 1) {
-              currentItem = new Declaration(`constant`);
-              currentItem.name = partsLower[1];
-              currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
-
-              currentItem.position = {
-                path: fileUri,
-                range: tokens[1].range
-              };
-
-              currentItem.range = {
-                start: currentStmtStart.line,
-                end: currentStmtStart.line
-              };
-
-              currentItem.readParms = true;
-
-              currentGroup = `constants`;
-
-              currentDescription = [];
-            }
-            break;
-
-          case `END-ENUM`:
-            if (currentItem && currentItem.type === `constant`) {
-              currentItem.range.end = currentStmtStart.line;
-
-              scope.addSymbol(currentItem);
-
-              resetDefinition = true;
-            }
-            break;
-
-          case `DCL-DS`:
-            if (currentItem === undefined) {
-              if (parts.length > 1) {
-                currentItem = new Declaration(`struct`);
-                currentItem.name = partsLower[1];
-                currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
-                currentItem.tags = currentTags;
-
-                currentItem.position = {
-                  path: fileUri,
-                  range: tokens[1].range
-                };
-
-                currentItem.range = {
-                  start: currentStmtStart.line,
-                  end: currentStmtStart.line
-                };
-
-                currentGroup = `structs`;
-
-                // Expand the LIKEDS value if there is one.
-                await expandDs(fileUri, tokens[1], currentItem);
-
-                // Does the keywords include a keyword that makes end-ds useless?
-                const singleLineDef = Object.keys(currentItem.keyword).some(keyword => oneLineTriggers[`DCL-DS`].some(trigger => keyword.startsWith(trigger)));
-                if (singleLineDef) {
-                  if (dsScopes.length > 0) {
-                    // If we're already inside a dsScope, that means we need to add this item to the current definition
-                    let lastItem = dsScopes[dsScopes.length - 1];
-                    lastItem.subItems.push(currentItem);
-                  } else {
-                    // Otherwise, we push as a new item
-                    currentItem.range.end = tokens[tokens.length-1].range.line;
-                    scope.addSymbol(currentItem);
+                  currentItem.range = {
+                    start: currentStmtStart.line,
+                    end: lineNumber
                   }
-                } else {
-                  // If it's not a single line defintion, flag the item to keep adding new fields
-                  currentItem.readParms = true;
-                  dsScopes.push(currentItem);
-                }
 
-                resetDefinition = true;
+                  await handleFSpec(currentItem, {
+                    keyword: currentItem.keyword,
+                    unique: parts.length.toString()
+                  });
 
-                currentDescription = [];
-              }
-            }
-            break;
-
-          case `END-DS`:
-            if (dsScopes.length > 0) {
-              const currentDs = dsScopes[dsScopes.length - 1];
-              currentDs.range.end = currentStmtStart.line;
-            }
-
-            if (dsScopes.length === 1) {
-              const ds = dsScopes.pop();
-              if (ds) {
-                scope.addSymbol(ds);
-              }
-            } else
-              if (dsScopes.length > 1) {
-                const ds = dsScopes.pop();
-                if (ds) {
-                  dsScopes[dsScopes.length - 1].subItems.push(ds);
-                }
-              }
-            break;
-
-          case `DCL-PR`:
-            if (currentItem === undefined) {
-              if (parts.length > 1) {
-                currentGroup = `procedures`;
-                currentItem = new Declaration(`procedure`);
-                currentItem.name = partsLower[1];
-                currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
-                currentItem.tags = currentTags;
-
-                currentItem.position = {
-                  path: fileUri,
-                  range: tokens[1].range
-                };
-
-                currentItem.readParms = true;
-
-                currentItem.range = {
-                  start: currentStmtStart.line,
-                  end: currentStmtStart.line
-                };
-
-                // Does the keywords include a keyword that makes end-ds useless?
-                if (Object.keys(currentItem.keyword).some(keyword => oneLineTriggers[`DCL-PR`].some(trigger => keyword.startsWith(trigger)))) {
-                  currentItem.range.end = currentStmtStart.line;
                   scope.addSymbol(currentItem);
                   resetDefinition = true;
                 }
-
-                currentDescription = [];
               }
-            }
-            break;
+              break;
 
-          case `END-PR`:
-            if (currentItem && currentItem.type === `procedure`) {
-              currentItem.range.end = currentStmtStart.line;
+            case `DCL-C`:
+              if (currentItem === undefined) {
+                if (parts.length > 1) {
+                  currentItem = new Declaration(`constant`);
+                  currentItem.name = partsLower[1];
+                  currentItem.keyword = Parser.expandKeywords(tokens.slice(2), true);
 
-              const isDefinedGlobally = scopes[0].findAll(currentItem.name).find(proc => proc.scope);
+                  currentItem.position = {
+                    path: fileUri,
+                    range: tokens[1].range
+                  };
 
-              // Don't re-add self. This can happens when `END-PR` is used in the wrong place.
-              if (!isDefinedGlobally) {
-                scope.addSymbol(currentItem);
-              }
+                  currentItem.range = {
+                    start: currentStmtStart.line,
+                    end: lineNumber
+                  };
 
-              resetDefinition = true;
-            }
-            break;
-
-          case `DCL-PROC`:
-            if (parts.length > 1) {
-              currentItem = new Declaration(`procedure`);
-
-              currentProcName = partsLower[1];
-              currentItem.name = currentProcName;
-              currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
-              currentItem.tags = currentTags;
-
-              currentItem.position = {
-                path: fileUri,
-                range: tokens[1].range
-              };
-
-              currentItem.readParms = false;
-
-              currentItem.range = {
-                start: currentStmtStart.line,
-                end: currentStmtStart.line
-              };
-
-              currentItem.scope = new Cache(undefined, true);
-
-              scope.addSymbol(currentItem);
-              resetDefinition = true;
-
-              scopes.push(currentItem.scope);
-            }
-            break;
-
-          case `DCL-PI`:
-            //Procedures can only exist in the global scope.
-            if (parts.length > 0) {
-              if (currentProcName) {
-                currentGroup = `procedures`;
-                currentItem = scopes[0].findAll(currentProcName).find(proc => !proc.prototype && proc.scope);
-              } else {
-                currentItem = new Declaration(`struct`);
-                currentItem.name = PROGRAMPARMS_NAME;
-              }
-
-              if (currentItem) {
-                const endInline = tokens.findIndex(part => part.value?.toUpperCase() === `END-PI`);
-
-                // Indicates that the PI starts and ends on the same line
-                if (endInline >= 0) {
-                  tokens.splice(endInline, 1);
-                  currentItem.readParms = false;
+                  scope.addSymbol(currentItem);
                   resetDefinition = true;
                 }
+              }
+              break;
 
-                currentItem.keyword = {
-                  ...currentItem.keyword,
-                  ...Parser.expandKeywords(tokens.slice(2))
-                }
+            case `DCL-S`:
+              if (parts.length > 1) {
+                currentItem = new Declaration(`variable`);
+                currentItem.name = partsLower[1];
+                currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
+                currentItem.tags = currentTags;
+
+                currentItem.position = {
+                  path: fileUri,
+                  range: tokens[1].range
+                };
+
+                currentItem.range = {
+                  start: currentStmtStart.line,
+                  end: lineNumber
+                };
+
+                scope.addSymbol(currentItem);
+                resetDefinition = true;
+              }
+              break;
+
+            case `DCL-ENUM`:
+              if (parts.length > 1) {
+                currentItem = new Declaration(`constant`);
+                currentItem.name = partsLower[1];
+                currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
+
+                currentItem.position = {
+                  path: fileUri,
+                  range: tokens[1].range
+                };
+
+                currentItem.range = {
+                  start: currentStmtStart.line,
+                  end: currentStmtStart.line
+                };
+
                 currentItem.readParms = true;
+
+                currentGroup = `constants`;
 
                 currentDescription = [];
               }
-            }
-            break;
+              break;
 
-          case `END-PI`:
-            //Procedures can only exist in the global scope.
-            if (currentProcName) {
-              currentItem = scopes[0].findAll(currentProcName).find(proc => !proc.prototype && proc.scope);
+            case `END-ENUM`:
+              if (currentItem && currentItem.type === `constant`) {
+                currentItem.range.end = currentStmtStart.line;
 
+                scope.addSymbol(currentItem);
+
+                resetDefinition = true;
+              }
+              break;
+
+            case `DCL-DS`:
+              if (currentItem === undefined) {
+                if (parts.length > 1) {
+                  currentItem = new Declaration(`struct`);
+                  currentItem.name = partsLower[1];
+                  currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
+                  currentItem.tags = currentTags;
+
+                  currentItem.position = {
+                    path: fileUri,
+                    range: tokens[1].range
+                  };
+
+                  currentItem.range = {
+                    start: currentStmtStart.line,
+                    end: currentStmtStart.line
+                  };
+
+                  currentGroup = `structs`;
+
+                  // Expand the LIKEDS value if there is one.
+                  await expandDs(fileUri, tokens[1], currentItem);
+
+                  // Does the keywords include a keyword that makes end-ds useless?
+                  const singleLineDef = Object.keys(currentItem.keyword).some(keyword => oneLineTriggers[`DCL-DS`].some(trigger => keyword.startsWith(trigger)));
+                  if (singleLineDef) {
+                    if (dsScopes.length > 0) {
+                      // If we're already inside a dsScope, that means we need to add this item to the current definition
+                      let lastItem = dsScopes[dsScopes.length - 1];
+                      lastItem.subItems.push(currentItem);
+                    } else {
+                      // Otherwise, we push as a new item
+                      currentItem.range.end = tokens[tokens.length - 1].range.line;
+                      scope.addSymbol(currentItem);
+                    }
+                  } else {
+                    // If it's not a single line defintion, flag the item to keep adding new fields
+                    currentItem.readParms = true;
+                    dsScopes.push(currentItem);
+                  }
+
+                  resetDefinition = true;
+
+                  currentDescription = [];
+                }
+              }
+              break;
+
+            case `END-DS`:
+              if (dsScopes.length > 0) {
+                const currentDs = dsScopes[dsScopes.length - 1];
+                currentDs.range.end = currentStmtStart.line;
+              }
+
+              if (dsScopes.length === 1) {
+                const ds = dsScopes.pop();
+                if (ds) {
+                  scope.addSymbol(ds);
+                }
+              } else
+                if (dsScopes.length > 1) {
+                  const ds = dsScopes.pop();
+                  if (ds) {
+                    dsScopes[dsScopes.length - 1].subItems.push(ds);
+                  }
+                }
+              break;
+
+            case `DCL-PR`:
+              if (currentItem === undefined) {
+                if (parts.length > 1) {
+                  currentGroup = `procedures`;
+                  currentItem = new Declaration(`procedure`);
+                  currentItem.name = partsLower[1];
+                  currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
+                  currentItem.tags = currentTags;
+
+                  currentItem.position = {
+                    path: fileUri,
+                    range: tokens[1].range
+                  };
+
+                  currentItem.readParms = true;
+
+                  currentItem.range = {
+                    start: currentStmtStart.line,
+                    end: currentStmtStart.line
+                  };
+
+                  // Does the keywords include a keyword that makes end-ds useless?
+                  if (Object.keys(currentItem.keyword).some(keyword => oneLineTriggers[`DCL-PR`].some(trigger => keyword.startsWith(trigger)))) {
+                    currentItem.range.end = currentStmtStart.line;
+                    scope.addSymbol(currentItem);
+                    resetDefinition = true;
+                  }
+
+                  currentDescription = [];
+                }
+              }
+              break;
+
+            case `END-PR`:
               if (currentItem && currentItem.type === `procedure`) {
+                currentItem.range.end = currentStmtStart.line;
+
+                const isDefinedGlobally = scopes[0].findAll(currentItem.name).find(proc => proc.scope);
+
+                // Don't re-add self. This can happens when `END-PR` is used in the wrong place.
+                if (!isDefinedGlobally) {
+                  scope.addSymbol(currentItem);
+                }
+
+                resetDefinition = true;
+              }
+              break;
+
+            case `DCL-PROC`:
+              if (parts.length > 1) {
+                currentItem = new Declaration(`procedure`);
+
+                currentProcName = partsLower[1];
+                currentItem.name = currentProcName;
+                currentItem.keyword = Parser.expandKeywords(tokens.slice(2));
+                currentItem.tags = currentTags;
+
+                currentItem.position = {
+                  path: fileUri,
+                  range: tokens[1].range
+                };
+
                 currentItem.readParms = false;
+
+                currentItem.range = {
+                  start: currentStmtStart.line,
+                  end: currentStmtStart.line
+                };
+
+                currentItem.scope = new Cache(undefined, true);
+
+                scope.addSymbol(currentItem);
+                resetDefinition = true;
+
+                scopes.push(currentItem.scope);
+              }
+              break;
+
+            case `DCL-PI`:
+              //Procedures can only exist in the global scope.
+              if (parts.length > 0) {
+                if (currentProcName) {
+                  currentGroup = `procedures`;
+                  currentItem = scopes[0].findAll(currentProcName).find(proc => !proc.prototype && proc.scope);
+                } else {
+                  currentItem = new Declaration(`struct`);
+                  currentItem.name = PROGRAMPARMS_NAME;
+                }
+
+                if (currentItem) {
+                  const endInline = tokens.findIndex(part => part.value?.toUpperCase() === `END-PI`);
+
+                  // Indicates that the PI starts and ends on the same line
+                  if (endInline >= 0) {
+                    tokens.splice(endInline, 1);
+                    currentItem.readParms = false;
+                    resetDefinition = true;
+                  }
+
+                  currentItem.keyword = {
+                    ...currentItem.keyword,
+                    ...Parser.expandKeywords(tokens.slice(2))
+                  }
+                  currentItem.readParms = true;
+
+                  currentDescription = [];
+                }
+              }
+              break;
+
+            case `END-PI`:
+              //Procedures can only exist in the global scope.
+              if (currentProcName) {
+                currentItem = scopes[0].findAll(currentProcName).find(proc => !proc.prototype && proc.scope);
+
+                if (currentItem && currentItem.type === `procedure`) {
+                  currentItem.readParms = false;
+                  currentItem.subItems.forEach(subItem => {
+                    subItem.type = `parameter`;
+                    scope.addSymbol(subItem);
+                  });
+
+                  resetDefinition = true;
+                }
+              } else if (currentItem && currentItem.name === PROGRAMPARMS_NAME) {
+                // Assign this scopes parameters to the subitems of the program parameters struct
+
                 currentItem.subItems.forEach(subItem => {
                   subItem.type = `parameter`;
                   scope.addSymbol(subItem);
@@ -1252,262 +1260,252 @@ export default class Parser {
 
                 resetDefinition = true;
               }
-            } else if (currentItem && currentItem.name === PROGRAMPARMS_NAME) {
-              // Assign this scopes parameters to the subitems of the program parameters struct
+              break;
 
-              currentItem.subItems.forEach(subItem => {
-                subItem.type = `parameter`;
-                scope.addSymbol(subItem);
-              });
+            case `END-PROC`:
+              //Procedures can only exist in the global scope.
+              if (scopes.length > 1) {
+                // currentItem = scopes[0].symbols.find(proc => !proc.prototype && proc.name === currentProcName);
+                currentItem = currentProcName ? scopes[0].findAll(currentProcName).find(proc => !proc.prototype && proc.scope) : undefined;
 
-              resetDefinition = true;
-            }
-            break;
+                if (currentItem && currentItem.type === `procedure`) {
+                  scopes.pop();
+                  currentItem.range.end = currentStmtStart.line;
+                  resetDefinition = true;
+                }
+              }
+              break;
 
-          case `END-PROC`:
-            //Procedures can only exist in the global scope.
-            if (scopes.length > 1) {
-              // currentItem = scopes[0].symbols.find(proc => !proc.prototype && proc.name === currentProcName);
-              currentItem = currentProcName ? scopes[0].findAll(currentProcName).find(proc => !proc.prototype && proc.scope) : undefined;
+            case `BEGSR`:
+              if (parts.length > 1) {
+                if (!scope.find(parts[1], `subroutine`)) {
+                  currentItem = new Declaration(`subroutine`);
+                  currentItem.name = partsLower[1];
+                  currentItem.keyword = { 'Subroutine': true };
 
-              if (currentItem && currentItem.type === `procedure`) {
-                scopes.pop();
+                  currentItem.position = {
+                    path: fileUri,
+                    range: tokens[1].range
+                  };
+
+                  currentItem.range = {
+                    start: currentStmtStart.line,
+                    end: currentStmtStart.line
+                  };
+
+                  currentDescription = [];
+                }
+              }
+              break;
+
+            case `ENDSR`:
+              if (currentItem && currentItem.type === `subroutine`) {
                 currentItem.range.end = currentStmtStart.line;
+                scope.addSymbol(currentItem);
                 resetDefinition = true;
               }
-            }
-            break;
+              break;
 
-          case `BEGSR`:
-            if (parts.length > 1) {
-              if (!scope.find(parts[1], `subroutine`)) {
-                currentItem = new Declaration(`subroutine`);
-                currentItem.name = partsLower[1];
-		            currentItem.keyword = {'Subroutine': true};
-
-                currentItem.position = {
-                  path: fileUri,
-                  range: tokens[1].range
-                };
-
-                currentItem.range = {
-                  start: currentStmtStart.line,
-                  end: currentStmtStart.line
-                };
-
-                currentDescription = [];
-              }
-            }
-            break;
-
-          case `ENDSR`:
-            if (currentItem && currentItem.type === `subroutine`) {
-              currentItem.range.end = currentStmtStart.line;
-              scope.addSymbol(currentItem);
-              resetDefinition = true;
-            }
-            break;
-
-          case `EXEC`:
-            const pIncludes = (value: string) => {
-              return parts.some(p => p === value);
-            }
-
-            const pIs = (part: string | undefined, value: string) => {
-              return part && part === value;
-            }
-
-            if (tokens.length > 2 && !pIncludes(`FETCH`)) {
-              // insert into XX.XX
-              // delete from xx.xx
-              // update xx.xx set
-              // select * into :x from xx.xx
-              // call xx.xx()
-              const preFileWords = [`INTO`, `FROM`, `UPDATE`, `CALL`, `JOIN`];
-              const ignoredWords = [`FINAL`, `SET`];
-
-              const cleanupObjectRef = (index: number) => {
-                let nameIndex = index;
-                const result: {
-                  schema: string | undefined,
-                  name: string,
-                  length: number,
-                  nameToken: Token | undefined,
-                } = {
-                  schema: undefined,
-                  name: partsLower[index],
-                  length: 1,
-                  nameToken: tokens[index]
-                }
-
-                const schemaSplit = [`.`, `/`].includes(parts[nameIndex + 1]);
-                if (schemaSplit) {
-                  result.schema = partsLower[index]
-                  result.name = partsLower[index + 2]
-                  result.length = 3;
-                  result.nameToken = tokens[index + 2];
-                  nameIndex += 2;
-                }
-
-                return result;
+            case `EXEC`:
+              const pIncludes = (value: string) => {
+                return parts.some(p => p === value);
               }
 
-              let isContinued = false;
+              const pIs = (part: string | undefined, value: string) => {
+                return part && part === value;
+              }
 
-              let ignoreCtes: string[] = [];
+              if (tokens.length > 2 && !pIncludes(`FETCH`)) {
+                // insert into XX.XX
+                // delete from xx.xx
+                // update xx.xx set
+                // select * into :x from xx.xx
+                // call xx.xx()
+                const preFileWords = [`INTO`, `FROM`, `UPDATE`, `CALL`, `JOIN`];
+                const ignoredWords = [`FINAL`, `SET`];
 
-              if (pIncludes(`WITH`)) {
-                for (let index = 4; index < tokens.length; index++) {
-                  if (pIs(parts[index], `AS`) && pIs(parts[index+1], `(`)) {
-                    ignoreCtes.push(parts[index-1].toUpperCase());
+                const cleanupObjectRef = (index: number) => {
+                  let nameIndex = index;
+                  const result: {
+                    schema: string | undefined,
+                    name: string,
+                    length: number,
+                    nameToken: Token | undefined,
+                  } = {
+                    schema: undefined,
+                    name: partsLower[index],
+                    length: 1,
+                    nameToken: tokens[index]
+                  }
+
+                  const schemaSplit = [`.`, `/`].includes(parts[nameIndex + 1]);
+                  if (schemaSplit) {
+                    result.schema = partsLower[index]
+                    result.name = partsLower[index + 2]
+                    result.length = 3;
+                    result.nameToken = tokens[index + 2];
+                    nameIndex += 2;
+                  }
+
+                  return result;
+                }
+
+                let isContinued = false;
+
+                let ignoreCtes: string[] = [];
+
+                if (pIncludes(`WITH`)) {
+                  for (let index = 4; index < tokens.length; index++) {
+                    if (pIs(parts[index], `AS`) && pIs(parts[index + 1], `(`)) {
+                      ignoreCtes.push(parts[index - 1].toUpperCase());
+                    }
                   }
                 }
-              }
 
-              for (let index = 0; index < parts.length; index++) {
-                const part = parts[index];
-                let inBlock = preFileWords.includes(part);
+                for (let index = 0; index < parts.length; index++) {
+                  const part = parts[index];
+                  let inBlock = preFileWords.includes(part);
 
-                if (
-                  (inBlock || isContinued) &&  // If this is true, usually means next word is the object
-                  (part === `INTO` ? parts[index-1] === `INSERT` : true) // INTO is special, as it can be used in both SELECT and INSERT
-                ) {
-                  if (index >= 0 && (index+1) < parts.length && tokens[index+1].type === `word` && !ignoredWords.includes(parts[index+1])) {
+                  if (
+                    (inBlock || isContinued) &&  // If this is true, usually means next word is the object
+                    (part === `INTO` ? parts[index - 1] === `INSERT` : true) // INTO is special, as it can be used in both SELECT and INSERT
+                  ) {
+                    if (index >= 0 && (index + 1) < parts.length && tokens[index + 1].type === `word` && !ignoredWords.includes(parts[index + 1])) {
 
-                    const qualifiedObjectPath = cleanupObjectRef(index+1);
+                      const qualifiedObjectPath = cleanupObjectRef(index + 1);
 
-                    index += (qualifiedObjectPath.length);
+                      index += (qualifiedObjectPath.length);
 
-                    isContinued = (parts[index+1] === `,`);
+                      isContinued = (parts[index + 1] === `,`);
 
-                    if (qualifiedObjectPath.name && !ignoreCtes.includes(qualifiedObjectPath.name.toUpperCase())) {
-                      const currentSqlItem = new Declaration(`file`);
-                      currentSqlItem.name = qualifiedObjectPath.name;
+                      if (qualifiedObjectPath.name && !ignoreCtes.includes(qualifiedObjectPath.name.toUpperCase())) {
+                        const currentSqlItem = new Declaration(`file`);
+                        currentSqlItem.name = qualifiedObjectPath.name;
 
-                      if (currentSqlItem.name)
-                        currentSqlItem.keyword = {};
+                        if (currentSqlItem.name)
+                          currentSqlItem.keyword = {};
 
-                      if (qualifiedObjectPath.schema) {
-                        currentSqlItem.tags.push({
-                          tag: `description`,
-                          content: qualifiedObjectPath.schema
-                        })
+                        if (qualifiedObjectPath.schema) {
+                          currentSqlItem.tags.push({
+                            tag: `description`,
+                            content: qualifiedObjectPath.schema
+                          })
+                        }
+
+                        currentSqlItem.position = {
+                          path: fileUri,
+                          range: qualifiedObjectPath.nameToken?.range || tokens[index]?.range || tokens[0].range
+                        };
+
+                        scope.sqlReferences.push(currentSqlItem);
                       }
-
-                      currentSqlItem.position = {
-                        path: fileUri,
-                        range: qualifiedObjectPath.nameToken?.range || tokens[index]?.range || tokens[0].range
-                      };
-
-                      scope.sqlReferences.push(currentSqlItem);
                     }
                   }
-                }
-              };
-            }
-            break;
+                };
+              }
+              break;
 
-          case `///`:
-            docs = !docs;
+            case `///`:
+              docs = !docs;
 
-            // When enabled
-            if (docs === true) {
-              currentTitle = undefined;
-              currentDescription = [];
-              currentTags = [];
-            }
-            break;
+              // When enabled
+              if (docs === true) {
+                currentTitle = undefined;
+                currentDescription = [];
+                currentTags = [];
+              }
+              break;
 
-          default:
-            if (lineIsComment) {
-              if (docs) {
-                const content = line.substring(2).trim();
-                if (content.length > 0) {
-                  if (content.startsWith(`@`)) {
-                    const lineData = content.substring(1).split(` `);
-                    currentTags.push({
-                      tag: lineData[0],
-                      content: lineData.slice(1).join(` `)
-                    });
-                  } else {
-                    if (currentTags.length > 0) {
-                      const lastTag = currentTags[currentTags.length - 1];
-                      lastTag.content += (lastTag.content.length === 0 ? `` : ` `) + content;
-
-                    } else if (!currentTags.some(tag => tag.tag === `title`)) {
+            default:
+              if (lineIsComment) {
+                if (docs) {
+                  const content = line.substring(2).trim();
+                  if (content.length > 0) {
+                    if (content.startsWith(`@`)) {
+                      const lineData = content.substring(1).split(` `);
                       currentTags.push({
-                        tag: `title`,
-                        content
+                        tag: lineData[0],
+                        content: lineData.slice(1).join(` `)
                       });
+                    } else {
+                      if (currentTags.length > 0) {
+                        const lastTag = currentTags[currentTags.length - 1];
+                        lastTag.content += (lastTag.content.length === 0 ? `` : ` `) + content;
 
-                      currentTags.push({
-                        tag: `description`,
-                        content: ``
-                      });
+                      } else if (!currentTags.some(tag => tag.tag === `title`)) {
+                        currentTags.push({
+                          tag: `title`,
+                          content
+                        });
 
+                        currentTags.push({
+                          tag: `description`,
+                          content: ``
+                        });
+
+                      }
                     }
                   }
+
+                } else {
+                  //Do nothing because it's a regular comment
                 }
 
               } else {
-                //Do nothing because it's a regular comment
-              }
-
-            } else {
-              if (!currentItem) {
-                if (dsScopes.length >= 1) {
-                  // We do this as there can be many levels to data structures in free format
-                  currentItem = dsScopes[dsScopes.length - 1];
-                }
-              }
-
-              if (currentItem && [`procedure`, `struct`, `constant`].includes(currentItem.type)) {
-                if (currentItem.readParms && parts.length > 0) {
-                  if (parts[0].startsWith(`DCL`)) {
-                    parts.slice(1);
-                    partsLower = partsLower.splice(1);
-                    tokens.splice(1);
+                if (!currentItem) {
+                  if (dsScopes.length >= 1) {
+                    // We do this as there can be many levels to data structures in free format
+                    currentItem = dsScopes[dsScopes.length - 1];
                   }
+                }
 
-                  currentSub = new Declaration(`subitem`);
-                  currentSub.name = (parts[0] === NO_NAME ? NO_NAME : partsLower[0]);
-                  currentSub.keyword = Parser.expandKeywords(tokens.slice(1));
+                if (currentItem && [`procedure`, `struct`, `constant`].includes(currentItem.type)) {
+                  if (currentItem.readParms && parts.length > 0) {
+                    if (parts[0].startsWith(`DCL`)) {
+                      parts.slice(1);
+                      partsLower = partsLower.splice(1);
+                      tokens.splice(1);
+                    }
 
-                  currentSub.position = {
-                    path: fileUri,
-                    range: tokens[0].range
-                  };
+                    currentSub = new Declaration(`subitem`);
+                    currentSub.name = (parts[0] === NO_NAME ? NO_NAME : partsLower[0]);
+                    currentSub.keyword = Parser.expandKeywords(tokens.slice(1));
 
-                  currentSub.range = {
-                    start: currentStmtStart.line,
-                    end: lineNumber
-                  };
+                    currentSub.position = {
+                      path: fileUri,
+                      range: tokens[0].range
+                    };
 
-                  // Add comments from the tags
-                  if (currentItem.type === `procedure`) {
-                    const paramTags = currentItem.tags.filter(tag => tag.tag === `param`);
-                    const paramTag = paramTags.length > currentItem.subItems.length ? paramTags[currentItem.subItems.length] : undefined;
-                    if (paramTag) {
-                      currentSub.tags = [{
-                        tag: `description`,
-                        content: paramTag.content
-                      }];
+                    currentSub.range = {
+                      start: currentStmtStart.line,
+                      end: lineNumber
+                    };
+
+                    // Add comments from the tags
+                    if (currentItem.type === `procedure`) {
+                      const paramTags = currentItem.tags.filter(tag => tag.tag === `param`);
+                      const paramTag = paramTags.length > currentItem.subItems.length ? paramTags[currentItem.subItems.length] : undefined;
+                      if (paramTag) {
+                        currentSub.tags = [{
+                          tag: `description`,
+                          content: paramTag.content
+                        }];
+                      }
+                    }
+
+                    // If the parameter has likeds, add the subitems to make it a struct.
+                    await expandDs(fileUri, tokens[0], currentSub);
+
+                    currentItem.subItems.push(currentSub);
+                    currentSub = undefined;
+
+                    if (currentItem.type === `struct` && currentItem.name !== PROGRAMPARMS_NAME) {
+                      resetDefinition = true;
                     }
                   }
-
-                  // If the parameter has likeds, add the subitems to make it a struct.
-                  await expandDs(fileUri, tokens[0], currentSub);
-
-                  currentItem.subItems.push(currentSub);
-                  currentSub = undefined;
-
-                  if (currentItem.type === `struct` && currentItem.name !== PROGRAMPARMS_NAME) {
-                    resetDefinition = true;
-                  }
                 }
               }
-            }
-            break;
+              break;
           }
 
         } else {
@@ -1518,577 +1516,577 @@ export default class Parser {
           }
 
           switch (spec) {
-          case `H`:
-            globalKeyword.push(line.substring(6));
-            break;
+            case `H`:
+              globalKeyword.push(line.substring(6));
+              break;
 
-          case `F`:
-            const fSpec = parseFLine(lineNumber, lineIndex, line);
+            case `F`:
+              const fSpec = parseFLine(lineNumber, lineIndex, line);
 
-            if (fSpec.name) {
-              currentItem = new Declaration(`file`);
-              currentItem.name = fSpec.name.value;
-              currentItem.keyword = fSpec.keywords;
+              if (fSpec.name) {
+                currentItem = new Declaration(`file`);
+                currentItem.name = fSpec.name.value;
+                currentItem.keyword = fSpec.keywords;
 
-              currentItem.position = {
-                path: fileUri,
-                range: fSpec.name.range
-              };
-
-              currentItem.range.start = lineNumber;
-              currentItem.range.end = lineNumber;
-
-              await handleFSpec(currentItem, {
-                keyword: fSpec.keywords,
-                unique: line.length.toString()
-              });
-
-              scope.addSymbol(currentItem);
-            } else {
-              // currentItem = scope.symbols[scope.symbols.length-1];
-              if (currentItem) {
-                currentItem.range.end = lineNumber;
-                currentItem.keyword = {
-                  ...fSpec.keywords,
-                  ...currentItem.keyword,
+                currentItem.position = {
+                  path: fileUri,
+                  range: fSpec.name.range
                 };
 
-                // We have to run this after the keyword is set
+                currentItem.range.start = lineNumber;
+                currentItem.range.end = lineNumber;
+
                 await handleFSpec(currentItem, {
                   keyword: fSpec.keywords,
                   unique: line.length.toString()
                 });
-              }
-            }
-
-            break;
-
-          case `I`:
-            const iSpec = parseISpec(lineNumber, lineIndex, line);
-
-            switch (iSpec.iType) {
-              case `continuationRecord`:
-                // Continuation record lines (blank file name, non-blank sequencing cols 17-18)
-                // are alternate indicator sets for the same physical record — nothing to do.
-                break;
-
-              case `programRecord`:
-              case `externalRecord`:
-                tokens = [iSpec.name, iSpec.recordIdentifyingIndicator];
-                currentItem = new Declaration(`input`);
-                currentItem.name = iSpec.name.value;
-                currentItem.keyword = {
-                  type: iSpec.iType === `programRecord` ? `program` : `external`
-                };
-
-                currentItem.position = {
-                  path: fileUri,
-                  range: iSpec.name.range
-                };
-
-                currentItem.range = {
-                  start: lineNumber,
-                  end: lineNumber
-                };
 
                 scope.addSymbol(currentItem);
+              } else {
+                // currentItem = scope.symbols[scope.symbols.length-1];
+                if (currentItem) {
+                  currentItem.range.end = lineNumber;
+                  currentItem.keyword = {
+                    ...fSpec.keywords,
+                    ...currentItem.keyword,
+                  };
 
-                break;
+                  // We have to run this after the keyword is set
+                  await handleFSpec(currentItem, {
+                    keyword: fSpec.keywords,
+                    unique: line.length.toString()
+                  });
+                }
+              }
 
-              case `programField`:
-                if (!currentItem) {
+              break;
+
+            case `I`:
+              const iSpec = parseISpec(lineNumber, lineIndex, line);
+
+              switch (iSpec.iType) {
+                case `continuationRecord`:
+                  // Continuation record lines (blank file name, non-blank sequencing cols 17-18)
+                  // are alternate indicator sets for the same physical record — nothing to do.
                   break;
-                }
 
-                tokens = [
-                  iSpec.fieldName,
-                  iSpec.controlLevel,
-                  iSpec.matchingFields,
-                  iSpec.fieldRecordRelation,
-                  ...iSpec.fieldIndicators
-                ];
-
-                // TODO: generate a type for this
-                let lookup = scope.find(iSpec.fieldName.value, undefined);
-
-                // This means the lookup is part of a struct
-                if (lookup && lookup.type === `subitem` && iSpec.dataFormat === undefined) {
-                  // So we assign it a default type if there isn't one
-                  iSpec.dataFormat = {
-                    type: `word`,
-                    value: iSpec.decimalPositions ? `S` : `A`,
-                    range: {start: 35, end: 37, line: lineNumber}
+                case `programRecord`:
+                case `externalRecord`:
+                  tokens = [iSpec.name, iSpec.recordIdentifyingIndicator];
+                  currentItem = new Declaration(`input`);
+                  currentItem.name = iSpec.name.value;
+                  currentItem.keyword = {
+                    type: iSpec.iType === `programRecord` ? `program` : `external`
                   };
-                }
-
-                const definedDataType = prettyTypeFromISpecTokens(iSpec);
-
-                if (lookup) {
-                  // TODO: does definedDataType match to lookup?
-                  if (Object.keys(lookup.keyword).length === 0) {
-                    lookup.keyword = definedDataType;
-                    // console.log({name: lookup.name, definedDataType});
-                  } else {
-                    // console.log({name: lookup.name, lookupKeyword: lookup.keyword, definedDataType});
-                  }
-
-                  currentItem.subItems.push(lookup);
-                } else {
-                  currentSub = new Declaration(`subitem`);
-                  currentSub.name = iSpec.fieldName.value;
-                  currentSub.keyword = definedDataType;
-                  currentSub.position = {
-                    path: fileUri,
-                    range: iSpec.fieldName.range
-                  };
-                  currentSub.range = {
-                    start: lineNumber,
-                    end: lineNumber
-                  };
-
-                  currentItem.subItems.push(currentSub);
-                }
-
-                currentItem.range.end = lineNumber;
-
-                break;
-
-              case `externalField`:
-                if (!currentItem) {
-                  break;
-                }
-
-                tokens = [
-                  iSpec.externalName,
-                  iSpec.fieldName,
-                  iSpec.controlLevel,
-                  iSpec.matchingFields,
-                  ...iSpec.fieldIndicators
-                ];
-                if (iSpec.externalName) {
-                  // Generate a type for this
-                  let lookup = scope.find(iSpec.externalName.value, undefined, true);
-                  if (lookup) {
-                    lookup.name = iSpec.fieldName.value;
-                    currentItem.subItems.push(lookup);
-                    currentItem.range.end = lineNumber;
-                  }
-                } else {
-                  let lookup = scope.find(iSpec.fieldName.value, undefined, true);
-                  if (lookup) {
-                    currentItem.subItems.push(lookup);
-                    currentItem.range.end = lineNumber;
-                  }
-                }
-                break;
-            }
-            break;
-
-          case `C`:
-            const cSpec = parseCLine(lineNumber, lineIndex, line);
-
-            tokens = [cSpec.clIndicator, cSpec.indicator, cSpec.ind1, cSpec.ind2, cSpec.ind3];
-
-            const fromToken = (token?: Token) => {
-              return token?.value !== undefined ? Parser.lineTokens(token.value, lineNumber, token.range.start) : [];
-            };
-
-            if (cSpec.opcode && ALLOWS_EXTENDED.includes(cSpec.opcode.value) && !cSpec.factor1 && cSpec.extended) {
-              tokens.push(...fromToken(cSpec.extended));
-            } else if (!cSpec.factor1 && !cSpec.opcode && cSpec.extended) {
-              tokens.push(...fromToken(cSpec.extended));
-            } else {
-              tokens.push(
-                ...fromToken(cSpec.factor1),
-                ...fromToken(cSpec.factor2),
-                ...fromToken(cSpec.result),
-              );
-
-              if (cSpec.result && cSpec.fieldLength) {
-                // This means we need to dynamically define this field
-                const fieldName = cSpec.result.value;
-                // Don't redefine this field.
-                if (!scopes[0].findDefinition(lineNumber, fieldName)) {
-                  const fieldLength = parseInt(cSpec.fieldLength.value);
-                  const decimals = cSpec.fieldDecimals ? parseInt(cSpec.fieldDecimals.value) : undefined;
-                  const type = decimals !== undefined ? `PACKED`: `CHAR`;
-
-                  currentSub = new Declaration(`variable`);
-                  currentSub.name = fieldName;
-                  currentSub.keyword = {[type]: `${fieldLength}${decimals !== undefined ? `:${decimals}` : ``}`};
-                  currentSub.position = {
-                    path: fileUri,
-                    range: cSpec.result.range
-                  };
-                  currentSub.range = {
-                    start: lineNumber,
-                    end: lineNumber
-                  };
-
-                  scope.addSymbol(currentSub);
-                }
-              }
-            }
-
-            switch (cSpec.opcode && cSpec.opcode.value) {
-            case `BEGSR`:
-              if (cSpec.factor1 && !scope.find(cSpec.factor1.value, `subroutine`)) {
-                currentItem = new Declaration(`subroutine`);
-                currentItem.name = cSpec.factor1.value;
-                currentItem.keyword = {'Subroutine': true};
-
-                currentItem.position = {
-                  path: fileUri,
-                  range: cSpec.factor1.range
-                };
-
-                currentItem.range = {
-                  start: lineNumber,
-                  end: lineNumber
-                };
-
-                currentDescription = [];
-              }
-              break;
-
-            case `ENDSR`:
-              if (currentItem && currentItem.type === `subroutine`) {
-                currentItem.range.end = lineNumber;
-                scope.addSymbol(currentItem);
-                resetDefinition = true;
-              }
-              break;
-
-            case `CALL`:
-              const callItem = new Declaration(`procedure`);
-              if (cSpec.factor2) {
-                const f2Value = cSpec.factor2.value;
-                callItem.name = (f2Value.startsWith(`'`) && f2Value.endsWith(`'`) ? f2Value.substring(1, f2Value.length-1) : f2Value);
-                callItem.keyword = {'CALL': true}
-                callItem.tags = currentTags;
-
-                callItem.position = {
-                  path: fileUri,
-                  range: cSpec.factor2.range
-                };
-
-                callItem.range = {
-                  start: lineNumber,
-                  end: lineNumber
-                };
-
-                scope.addSymbol(callItem);
-              }
-              break;
-
-            case `TAG`:
-              const tagItem = new Declaration(`tag`);
-              if (cSpec.factor1) {
-                tagItem.name = cSpec.factor1.value;
-                tagItem.position = {
-                  path: fileUri,
-                  range: cSpec.factor1.range
-                };
-
-                tagItem.range = {
-                  start: lineNumber,
-                  end: lineNumber
-                };
-
-                scope.addSymbol(tagItem);
-              }
-              break;
-            }
-
-            break;
-          case `P`:
-            const pSpec = parsePLine(line, lineNumber, lineIndex);
-
-            if (pSpec.potentialName) {
-              pushPotentialNameToken(pSpec.potentialName);
-
-              tokens = [pSpec.potentialName];
-            } else {
-              if (pSpec.start) {
-                tokens = [...pSpec.keywordsRaw, pSpec.name];
-
-                if (pSpec.name && pSpec.name.value.length > 0) {
-                  pushPotentialNameToken(pSpec.name);
-                }
-
-                const currentNameToken = getPotentialNameToken();
-
-                if (currentNameToken) {
-                  currentItem = new Declaration(`procedure`);
-
-                  currentProcName = currentNameToken.value;
-                  currentItem.name = currentProcName || NO_NAME;
-                  currentItem.keyword = pSpec.keywords;
 
                   currentItem.position = {
                     path: fileUri,
-                    range: currentNameToken.range
+                    range: iSpec.name.range
                   };
 
                   currentItem.range = {
-                    start: currentNameToken.range.line,
-                    end: currentNameToken.range.line
+                    start: lineNumber,
+                    end: lineNumber
                   };
 
-                  currentItem.scope = new Cache(undefined, true);
-
                   scope.addSymbol(currentItem);
-                  resetDefinition = true;
 
-                  scopes.push(currentItem.scope);
-                }
+                  break;
+
+                case `programField`:
+                  if (!currentItem) {
+                    break;
+                  }
+
+                  tokens = [
+                    iSpec.fieldName,
+                    iSpec.controlLevel,
+                    iSpec.matchingFields,
+                    iSpec.fieldRecordRelation,
+                    ...iSpec.fieldIndicators
+                  ];
+
+                  // TODO: generate a type for this
+                  let lookup = scope.find(iSpec.fieldName.value, undefined);
+
+                  // This means the lookup is part of a struct
+                  if (lookup && lookup.type === `subitem` && iSpec.dataFormat === undefined) {
+                    // So we assign it a default type if there isn't one
+                    iSpec.dataFormat = {
+                      type: `word`,
+                      value: iSpec.decimalPositions ? `S` : `A`,
+                      range: { start: 35, end: 37, line: lineNumber }
+                    };
+                  }
+
+                  const definedDataType = prettyTypeFromISpecTokens(iSpec);
+
+                  if (lookup) {
+                    // TODO: does definedDataType match to lookup?
+                    if (Object.keys(lookup.keyword).length === 0) {
+                      lookup.keyword = definedDataType;
+                      // console.log({name: lookup.name, definedDataType});
+                    } else {
+                      // console.log({name: lookup.name, lookupKeyword: lookup.keyword, definedDataType});
+                    }
+
+                    currentItem.subItems.push(lookup);
+                  } else {
+                    currentSub = new Declaration(`subitem`);
+                    currentSub.name = iSpec.fieldName.value;
+                    currentSub.keyword = definedDataType;
+                    currentSub.position = {
+                      path: fileUri,
+                      range: iSpec.fieldName.range
+                    };
+                    currentSub.range = {
+                      start: lineNumber,
+                      end: lineNumber
+                    };
+
+                    currentItem.subItems.push(currentSub);
+                  }
+
+                  currentItem.range.end = lineNumber;
+
+                  break;
+
+                case `externalField`:
+                  if (!currentItem) {
+                    break;
+                  }
+
+                  tokens = [
+                    iSpec.externalName,
+                    iSpec.fieldName,
+                    iSpec.controlLevel,
+                    iSpec.matchingFields,
+                    ...iSpec.fieldIndicators
+                  ];
+                  if (iSpec.externalName) {
+                    // Generate a type for this
+                    let lookup = scope.find(iSpec.externalName.value, undefined, true);
+                    if (lookup) {
+                      lookup.name = iSpec.fieldName.value;
+                      currentItem.subItems.push(lookup);
+                      currentItem.range.end = lineNumber;
+                    }
+                  } else {
+                    let lookup = scope.find(iSpec.fieldName.value, undefined, true);
+                    if (lookup) {
+                      currentItem.subItems.push(lookup);
+                      currentItem.range.end = lineNumber;
+                    }
+                  }
+                  break;
+              }
+              break;
+
+            case `C`:
+              const cSpec = parseCLine(lineNumber, lineIndex, line);
+
+              tokens = [cSpec.clIndicator, cSpec.indicator, cSpec.ind1, cSpec.ind2, cSpec.ind3];
+
+              const fromToken = (token?: Token) => {
+                return token?.value !== undefined ? Parser.lineTokens(token.value, lineNumber, token.range.start) : [];
+              };
+
+              if (cSpec.opcode && ALLOWS_EXTENDED.includes(cSpec.opcode.value) && !cSpec.factor1 && cSpec.extended) {
+                tokens.push(...fromToken(cSpec.extended));
+              } else if (!cSpec.factor1 && !cSpec.opcode && cSpec.extended) {
+                tokens.push(...fromToken(cSpec.extended));
               } else {
-                if (scopes.length > 1) {
-                  //Procedures can only exist in the global scope.
-                  currentItem = currentProcName ? scopes[0].find(currentProcName) : undefined;
+                tokens.push(
+                  ...fromToken(cSpec.factor1),
+                  ...fromToken(cSpec.factor2),
+                  ...fromToken(cSpec.result),
+                );
 
-                  if (currentItem && currentItem.type === `procedure`) {
-                    scopes.pop();
+                if (cSpec.result && cSpec.fieldLength) {
+                  // This means we need to dynamically define this field
+                  const fieldName = cSpec.result.value;
+                  // Don't redefine this field.
+                  if (!scopes[0].findDefinition(lineNumber, fieldName)) {
+                    const fieldLength = parseInt(cSpec.fieldLength.value);
+                    const decimals = cSpec.fieldDecimals ? parseInt(cSpec.fieldDecimals.value) : undefined;
+                    const type = decimals !== undefined ? `PACKED` : `CHAR`;
+
+                    currentSub = new Declaration(`variable`);
+                    currentSub.name = fieldName;
+                    currentSub.keyword = { [type]: `${fieldLength}${decimals !== undefined ? `:${decimals}` : ``}` };
+                    currentSub.position = {
+                      path: fileUri,
+                      range: cSpec.result.range
+                    };
+                    currentSub.range = {
+                      start: lineNumber,
+                      end: lineNumber
+                    };
+
+                    scope.addSymbol(currentSub);
+                  }
+                }
+              }
+
+              switch (cSpec.opcode && cSpec.opcode.value) {
+                case `BEGSR`:
+                  if (cSpec.factor1 && !scope.find(cSpec.factor1.value, `subroutine`)) {
+                    currentItem = new Declaration(`subroutine`);
+                    currentItem.name = cSpec.factor1.value;
+                    currentItem.keyword = { 'Subroutine': true };
+
+                    currentItem.position = {
+                      path: fileUri,
+                      range: cSpec.factor1.range
+                    };
+
+                    currentItem.range = {
+                      start: lineNumber,
+                      end: lineNumber
+                    };
+
+                    currentDescription = [];
+                  }
+                  break;
+
+                case `ENDSR`:
+                  if (currentItem && currentItem.type === `subroutine`) {
                     currentItem.range.end = lineNumber;
+                    scope.addSymbol(currentItem);
                     resetDefinition = true;
                   }
-                }
-              }
-            }
-            break;
-
-          case `D`:
-            const dSpec = parseDLine(lineNumber, lineIndex, line);
-
-            if (dSpec.potentialName) {
-              pushPotentialNameToken(dSpec.potentialName);
-              tokens = [dSpec.potentialName];
-              continue;
-            } else {
-
-              if (dSpec.name && dSpec.name.value.length > 0) {
-                pushPotentialNameToken(dSpec.name);
-              }
-
-              tokens = [dSpec.field, ...dSpec.keywordsRaw, dSpec.name];
-
-              const currentNameToken = getPotentialNameToken();
-
-              switch (dSpec.field && dSpec.field.value) {
-              case `C`:
-                currentItem = new Declaration(`constant`);
-                currentItem.name = currentNameToken?.value || NO_NAME;
-                currentItem.keyword = dSpec.keywords || {};
-
-                // TODO: line number might be different with ...?
-                currentItem.position = {
-                  path: fileUri,
-                  range: dSpec.field.range
-                };
-
-                currentItem.range = {
-                  start: currentNameToken?.range.line || lineNumber,
-                  end: currentItem.position.range.line
-                };
-
-                scope.addSymbol(currentItem);
-                resetDefinition = true;
-                break;
-              case `S`:
-
-                if (!currentNameToken) {
-                  // If we don't have a current name token
-                  // we cannot create a variable declaration (RNF3316)
                   break;
-                }
 
-                currentItem = new Declaration(`variable`);
-                currentItem.name = currentNameToken.value || NO_NAME;
-                currentItem.keyword = {
-                  ...dSpec.keywords,
-                  ...prettyTypeFromDSpecTokens(dSpec),
-                }
+                case `CALL`:
+                  const callItem = new Declaration(`procedure`);
+                  if (cSpec.factor2) {
+                    const f2Value = cSpec.factor2.value;
+                    callItem.name = (f2Value.startsWith(`'`) && f2Value.endsWith(`'`) ? f2Value.substring(1, f2Value.length - 1) : f2Value);
+                    callItem.keyword = { 'CALL': true }
+                    callItem.tags = currentTags;
 
-                // TODO: line number might be different with ...?
-                currentItem.position = {
-                  path: fileUri,
-                  range: currentNameToken.range
-                };
+                    callItem.position = {
+                      path: fileUri,
+                      range: cSpec.factor2.range
+                    };
 
-                currentItem.range = {
-                  start: currentNameToken.range.line,
-                  end: currentItem.position.range.line
-                };
+                    callItem.range = {
+                      start: lineNumber,
+                      end: lineNumber
+                    };
 
-                scope.addSymbol(currentItem);
-                resetDefinition = true;
-                break;
-
-              case `DS`:
-                currentItem = new Declaration(`struct`);
-                currentItem.name = currentNameToken?.value || NO_NAME;
-                currentItem.keyword = dSpec.keywords;
-
-                currentItem.position = {
-                  path: fileUri,
-                  range: currentNameToken?.range || dSpec.field.range
-                };
-
-                currentItem.range = {
-                  start: currentItem.position.range.line,
-                  end: currentItem.position.range.line
-                };
-
-                if (currentNameToken) {
-                  await expandDs(fileUri, currentNameToken, currentItem);
-                }
-
-                currentGroup = `structs`;
-                scope.addSymbol(currentItem);
-                resetDefinition = true;
-                break;
-
-              case `PR`:
-                currentItem = new Declaration(`procedure`);
-                currentItem.name = currentNameToken?.value || NO_NAME;
-                currentItem.keyword = {
-                  ...prettyTypeFromDSpecTokens(dSpec),
-                  ...dSpec.keywords
-                }
-
-                currentItem.position = {
-                  path: fileUri,
-                  range: getPotentialNameToken()?.range || dSpec.field.range
-                };
-
-                currentItem.range = {
-                  start: currentItem.position.range.line,
-                  end: currentItem.position.range.line
-                };
-
-                currentGroup = `procedures`;
-                scope.addSymbol(currentItem);
-                currentDescription = [];
-                break;
-
-              case `PI`:
-                //Procedures can only exist in the global scope.
-                if (currentProcName) {
-                  currentItem = scopes[0].findAll(currentProcName).find(proc => !proc.prototype && proc.scope);
-
-                  currentGroup = `procedures`;
-                  if (currentItem) {
-                    currentItem.keyword = {
-                      ...currentItem.keyword,
-                      ...prettyTypeFromDSpecTokens(dSpec),
-                      ...dSpec.keywords
-                    }
+                    scope.addSymbol(callItem);
                   }
-                } else {
-                  currentGroup = `parameters`;
-                }
-                break;
+                  break;
 
-              default:
-                // No type, must be either a struct subfield OR a parameter
-                if (!currentItem) {
-                  switch (currentGroup) {
-                  case `structs`:
-                  case `procedures`:
-                    // We have to do this backwards lookup to find the definition
-                    // because in fixed format, currentItem is not defined. So
-                    // we go find the latest procedure/structure defined
-                    let validScope;
-                    for (let i = scopes.length - 1; i >= 0; i--) {
-                      validScope = scopes[i];
-                      if (validScope[currentGroup].length > 0) break;
-                    }
+                case `TAG`:
+                  const tagItem = new Declaration(`tag`);
+                  if (cSpec.factor1) {
+                    tagItem.name = cSpec.factor1.value;
+                    tagItem.position = {
+                      path: fileUri,
+                      range: cSpec.factor1.range
+                    };
 
-                    if (validScope && validScope[currentGroup].length > 0) {
-                      currentItem = validScope[currentGroup][validScope[currentGroup].length - 1];
-                    }
-                    break;
+                    tagItem.range = {
+                      start: lineNumber,
+                      end: lineNumber
+                    };
 
-                  case `parameters`:
-                    currentItem = new Declaration(`struct`);
-                    currentItem.name = PROGRAMPARMS_NAME;
-                    break;
+                    scope.addSymbol(tagItem);
                   }
-                }
+                  break;
+              }
 
-                if (currentItem) {
-                  const isProgramParameter = currentItem.name === PROGRAMPARMS_NAME;
+              break;
+            case `P`:
+              const pSpec = parsePLine(line, lineNumber, lineIndex);
 
-                  // This happens when it's a blank parm.
-                  const baseToken = dSpec.type || dSpec.len;
-                  if (!potentialName && baseToken) {
-                    pushPotentialNameToken({
-                      ...baseToken,
-                      value: NO_NAME
-                    });
+              if (pSpec.potentialName) {
+                pushPotentialNameToken(pSpec.potentialName);
+
+                tokens = [pSpec.potentialName];
+              } else {
+                if (pSpec.start) {
+                  tokens = [...pSpec.keywordsRaw, pSpec.name];
+
+                  if (pSpec.name && pSpec.name.value.length > 0) {
+                    pushPotentialNameToken(pSpec.name);
                   }
 
                   const currentNameToken = getPotentialNameToken();
 
-                  if (potentialName) {
-                    currentSub = new Declaration(isProgramParameter ? `parameter` : `subitem`);
-                    currentSub.name = currentNameToken?.value || NO_NAME;
-                    currentSub.keyword = {
-                      ...prettyTypeFromDSpecTokens(dSpec),
-                      ...dSpec.keywords
+                  if (currentNameToken) {
+                    currentItem = new Declaration(`procedure`);
+
+                    currentProcName = currentNameToken.value;
+                    currentItem.name = currentProcName || NO_NAME;
+                    currentItem.keyword = pSpec.keywords;
+
+                    currentItem.position = {
+                      path: fileUri,
+                      range: currentNameToken.range
+                    };
+
+                    currentItem.range = {
+                      start: currentNameToken.range.line,
+                      end: currentNameToken.range.line
+                    };
+
+                    currentItem.scope = new Cache(undefined, true);
+
+                    scope.addSymbol(currentItem);
+                    resetDefinition = true;
+
+                    scopes.push(currentItem.scope);
+                  }
+                } else {
+                  if (scopes.length > 1) {
+                    //Procedures can only exist in the global scope.
+                    currentItem = currentProcName ? scopes[0].find(currentProcName) : undefined;
+
+                    if (currentItem && currentItem.type === `procedure`) {
+                      scopes.pop();
+                      currentItem.range.end = lineNumber;
+                      resetDefinition = true;
+                    }
+                  }
+                }
+              }
+              break;
+
+            case `D`:
+              const dSpec = parseDLine(lineNumber, lineIndex, line);
+
+              if (dSpec.potentialName) {
+                pushPotentialNameToken(dSpec.potentialName);
+                tokens = [dSpec.potentialName];
+                continue;
+              } else {
+
+                if (dSpec.name && dSpec.name.value.length > 0) {
+                  pushPotentialNameToken(dSpec.name);
+                }
+
+                tokens = [dSpec.field, ...dSpec.keywordsRaw, dSpec.name];
+
+                const currentNameToken = getPotentialNameToken();
+
+                switch (dSpec.field && dSpec.field.value) {
+                  case `C`:
+                    currentItem = new Declaration(`constant`);
+                    currentItem.name = currentNameToken?.value || NO_NAME;
+                    currentItem.keyword = dSpec.keywords || {};
+
+                    // TODO: line number might be different with ...?
+                    currentItem.position = {
+                      path: fileUri,
+                      range: dSpec.field.range
+                    };
+
+                    currentItem.range = {
+                      start: currentNameToken?.range.line || lineNumber,
+                      end: currentItem.position.range.line
+                    };
+
+                    scope.addSymbol(currentItem);
+                    resetDefinition = true;
+                    break;
+                  case `S`:
+
+                    if (!currentNameToken) {
+                      // If we don't have a current name token
+                      // we cannot create a variable declaration (RNF3316)
+                      break;
                     }
 
-                    currentSub.position = {
+                    currentItem = new Declaration(`variable`);
+                    currentItem.name = currentNameToken.value || NO_NAME;
+                    currentItem.keyword = {
+                      ...dSpec.keywords,
+                      ...prettyTypeFromDSpecTokens(dSpec),
+                    }
+
+                    // TODO: line number might be different with ...?
+                    currentItem.position = {
+                      path: fileUri,
+                      range: currentNameToken.range
+                    };
+
+                    currentItem.range = {
+                      start: currentNameToken.range.line,
+                      end: currentItem.position.range.line
+                    };
+
+                    scope.addSymbol(currentItem);
+                    resetDefinition = true;
+                    break;
+
+                  case `DS`:
+                    currentItem = new Declaration(`struct`);
+                    currentItem.name = currentNameToken?.value || NO_NAME;
+                    currentItem.keyword = dSpec.keywords;
+
+                    currentItem.position = {
                       path: fileUri,
                       range: currentNameToken?.range || dSpec.field.range
                     };
 
-                    currentSub.range = {
-                      start: lineNumber,
-                      end: lineNumber
-                    }
+                    currentItem.range = {
+                      start: currentItem.position.range.line,
+                      end: currentItem.position.range.line
+                    };
 
-                    // If the parameter has likeds, add the subitems to make it a struct.
                     if (currentNameToken) {
-                      await expandDs(fileUri, currentNameToken, currentSub);
+                      await expandDs(fileUri, currentNameToken, currentItem);
                     }
 
-                    if (isProgramParameter) {
-                      scope.addSymbol(currentSub);
-                    } else {
-                      currentItem.subItems.push(currentSub);
-                    }
-                    currentSub = undefined;
-
+                    currentGroup = `structs`;
+                    scope.addSymbol(currentItem);
                     resetDefinition = true;
-                  } else {
-                    if (currentItem) {
-                      if (currentItem.subItems.length > 0) {
-                        currentItem.subItems[currentItem.subItems.length - 1].keyword = {
-                          ...currentItem.subItems[currentItem.subItems.length - 1].keyword,
-                          ...prettyTypeFromDSpecTokens(dSpec),
-                          ...dSpec.keywords
-                        };
+                    break;
 
-                        currentItem.subItems[currentItem.subItems.length - 1].range.end = lineNumber;
-                      } else {
+                  case `PR`:
+                    currentItem = new Declaration(`procedure`);
+                    currentItem.name = currentNameToken?.value || NO_NAME;
+                    currentItem.keyword = {
+                      ...prettyTypeFromDSpecTokens(dSpec),
+                      ...dSpec.keywords
+                    }
+
+                    currentItem.position = {
+                      path: fileUri,
+                      range: getPotentialNameToken()?.range || dSpec.field.range
+                    };
+
+                    currentItem.range = {
+                      start: currentItem.position.range.line,
+                      end: currentItem.position.range.line
+                    };
+
+                    currentGroup = `procedures`;
+                    scope.addSymbol(currentItem);
+                    currentDescription = [];
+                    break;
+
+                  case `PI`:
+                    //Procedures can only exist in the global scope.
+                    if (currentProcName) {
+                      currentItem = scopes[0].findAll(currentProcName).find(proc => !proc.prototype && proc.scope);
+
+                      currentGroup = `procedures`;
+                      if (currentItem) {
                         currentItem.keyword = {
                           ...currentItem.keyword,
+                          ...prettyTypeFromDSpecTokens(dSpec),
+                          ...dSpec.keywords
+                        }
+                      }
+                    } else {
+                      currentGroup = `parameters`;
+                    }
+                    break;
+
+                  default:
+                    // No type, must be either a struct subfield OR a parameter
+                    if (!currentItem) {
+                      switch (currentGroup) {
+                        case `structs`:
+                        case `procedures`:
+                          // We have to do this backwards lookup to find the definition
+                          // because in fixed format, currentItem is not defined. So
+                          // we go find the latest procedure/structure defined
+                          let validScope;
+                          for (let i = scopes.length - 1; i >= 0; i--) {
+                            validScope = scopes[i];
+                            if (validScope[currentGroup].length > 0) break;
+                          }
+
+                          if (validScope && validScope[currentGroup].length > 0) {
+                            currentItem = validScope[currentGroup][validScope[currentGroup].length - 1];
+                          }
+                          break;
+
+                        case `parameters`:
+                          currentItem = new Declaration(`struct`);
+                          currentItem.name = PROGRAMPARMS_NAME;
+                          break;
+                      }
+                    }
+
+                    if (currentItem) {
+                      const isProgramParameter = currentItem.name === PROGRAMPARMS_NAME;
+
+                      // This happens when it's a blank parm.
+                      const baseToken = dSpec.type || dSpec.len;
+                      if (!potentialName && baseToken) {
+                        pushPotentialNameToken({
+                          ...baseToken,
+                          value: NO_NAME
+                        });
+                      }
+
+                      const currentNameToken = getPotentialNameToken();
+
+                      if (potentialName) {
+                        currentSub = new Declaration(isProgramParameter ? `parameter` : `subitem`);
+                        currentSub.name = currentNameToken?.value || NO_NAME;
+                        currentSub.keyword = {
+                          ...prettyTypeFromDSpecTokens(dSpec),
                           ...dSpec.keywords
                         }
 
+                        currentSub.position = {
+                          path: fileUri,
+                          range: currentNameToken?.range || dSpec.field.range
+                        };
+
+                        currentSub.range = {
+                          start: lineNumber,
+                          end: lineNumber
+                        }
+
+                        // If the parameter has likeds, add the subitems to make it a struct.
+                        if (currentNameToken) {
+                          await expandDs(fileUri, currentNameToken, currentSub);
+                        }
+
+                        if (isProgramParameter) {
+                          scope.addSymbol(currentSub);
+                        } else {
+                          currentItem.subItems.push(currentSub);
+                        }
+                        currentSub = undefined;
+
+                        resetDefinition = true;
+                      } else {
+                        if (currentItem) {
+                          if (currentItem.subItems.length > 0) {
+                            currentItem.subItems[currentItem.subItems.length - 1].keyword = {
+                              ...currentItem.subItems[currentItem.subItems.length - 1].keyword,
+                              ...prettyTypeFromDSpecTokens(dSpec),
+                              ...dSpec.keywords
+                            };
+
+                            currentItem.subItems[currentItem.subItems.length - 1].range.end = lineNumber;
+                          } else {
+                            currentItem.keyword = {
+                              ...currentItem.keyword,
+                              ...dSpec.keywords
+                            }
+
+                          }
+                        }
                       }
+
+                      currentItem.range.end = lineNumber;
                     }
-                  }
-
-                  currentItem.range.end = lineNumber;
+                    break;
                 }
-                break;
-              }
 
-              potentialName = undefined;
-            }
-            break;
+                potentialName = undefined;
+              }
+              break;
           }
         }
 
@@ -2127,7 +2125,7 @@ export default class Parser {
     return parsedData;
   }
 
-  static getTokens(content: string|string[]|Token[], lineNumber?: number, baseIndex?: number): Token[] {
+  static getTokens(content: string | string[] | Token[], lineNumber?: number, baseIndex?: number): Token[] {
     const resolvedLineNumber = lineNumber ?? 0;
     const resolvedBaseIndex = baseIndex ?? 0;
     if (Array.isArray(content) && typeof content[0] === `string`) {

--- a/language/opm/parser.ts
+++ b/language/opm/parser.ts
@@ -2,9 +2,7 @@ import Cache from '../models/cache';
 import Declaration, { DeclarationType } from '../models/declaration';
 import { Keywords } from '../ile/parserTypes';
 import { EmbeddedSqlSpecification, InputConstantEntry, parseSpecification } from './specs';
-
-export type tablePromise = (name: string, aliases?: boolean) => Promise<Declaration[]>;
-export type includeFilePromise = (baseFile: string, includeString: string) => Promise<{found: boolean, uri?: string, content?: string}>;
+import type { tablePromise, includeFilePromise } from '../parserFactory';
 
 export interface ParseOptions {
   withIncludes?: boolean;

--- a/language/parserFactory.ts
+++ b/language/parserFactory.ts
@@ -8,7 +8,8 @@ import {
 } from './utils/fileRouting';
 
 export type tablePromise = (name: string, aliases?: boolean) => Promise<Declaration[]>;
-export type includeFilePromise = (baseFile: string, includeString: string) => Promise<{found: boolean, uri?: string, content?: string}>;
+export type IncludeFetchResult = { found: boolean, uri?: string, content?: string };
+export type includeFilePromise = (baseFile: string, includeString: string) => Promise<IncludeFetchResult>;
 
 /**
  * Common interface for both parsers

--- a/tests/suite/directives.test.ts
+++ b/tests/suite/directives.test.ts
@@ -795,3 +795,47 @@ test('editing around include directives maintains offsets', async () => {
   // LocalVar should shift down by 1 line
   expect(localVarLine2).toBe(localVarLine1! + 1);
 });
+
+test('include graph should fetch shared include once per parse pass (issue 503)', async () => {
+  const graphParser = new Parser();
+
+  const includeContents: { [name: string]: string } = {
+    'b.rpgleinc': [`**FREE`, `/copy 'd.rpgleinc'`].join(`\n`),
+    'c.rpgleinc': [`**FREE`, `/copy 'd.rpgleinc'`].join(`\n`),
+    'd.rpgleinc': [`**FREE`, `Dcl-S SharedValue Int(10);`].join(`\n`),
+  };
+
+  const fetchCounts: { [name: string]: number } = {};
+
+  graphParser.setIncludeFileFetch(async (_baseFile: string, includeFile: string) => {
+    const normalized = includeFile.replace(/^['"]|['"]$/g, ``).toLowerCase();
+    fetchCounts[normalized] = (fetchCounts[normalized] || 0) + 1;
+
+    const content = includeContents[normalized];
+    if (content) {
+      return {
+        found: true,
+        uri: `mock://${normalized}`,
+        content,
+      };
+    }
+
+    return {
+      found: false,
+    };
+  });
+
+  const entry = [
+    `**FREE`,
+    `/copy 'b.rpgleinc'`,
+    `/copy 'c.rpgleinc'`,
+    `return;`,
+  ].join(`\n`);
+
+  const cache = await graphParser.getDocs(`a.rpgle`, entry, { withIncludes: true, ignoreCache: true });
+
+  expect(cache).toBeDefined();
+  expect(fetchCounts[`b.rpgleinc`]).toBe(1);
+  expect(fetchCounts[`c.rpgleinc`]).toBe(1);
+  expect(fetchCounts[`d.rpgleinc`]).toBe(1);
+});


### PR DESCRIPTION
## Summary
- add a regression test that reproduces issue 503 include graph behavior (a -> b,c -> d)
- ensure shared include targets are fetched once per parse pass
- keep existing include parsing behavior unchanged while preventing duplicate loads

## Implementation
- parser now memoizes include fetch promises during a single getDocs parse pass
- memoization key uses parent directory context plus include literal to avoid repeated fetches in shared include graphs
- existing include URI dedup logic remains in place for parse recursion

## Validation
- npm test -- tests/suite/directives.test.ts
- npm test -- tests/suite/files.test.ts tests/suite/references.test.ts tests/suite/fixed.test.ts tests/suite/linter.test.ts
- 217 tests passed in these suites

Fixes #503
